### PR TITLE
Add git hook templates and disable incremental update on bump

### DIFF
--- a/.cz.changelog.md.j2
+++ b/.cz.changelog.md.j2
@@ -1,0 +1,19 @@
+{% for entry in tree %}
+
+## {{ entry.version }}{% if entry.date %} ({{ entry.date }}){% endif %}
+
+{% for change_key, changes in entry.changes.items() %}
+
+{% if change_key %}
+### {{ change_key.replace('Feat', 'Feature') }}
+{% endif %}
+
+{% for change in changes %}
+{% if change.scope %}
+- **{{ change.scope }}**: {{ change.message }}
+{% elif change.message %}
+- {{ change.message }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 1.1.0
+  version: 1.2.0
   version_scheme: semver

--- a/.cz.yaml
+++ b/.cz.yaml
@@ -2,9 +2,11 @@
 commitizen:
   annotated_tag: true
   bump_message: "bump: version $current_version \u2192 $new_version"
+  changelog_incremental: false
   gpg_sign: true
   name: cz_conventional_commits
   tag_format: v$version
+  template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
   version: 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
+## v1.2.0 (2024-03-08)
+
+### Feature
+
+- **git**: add git hook templates for pre-push & prepare-commit-msg
+
+### Fix
+
+- **git**: add -nT flags to ln command to prevent creating recursive symlink
+- **git**: remove recursive symlink
+
 ## v1.1.0 (2024-02-05)
 
-### Feat
+### Feature
 
 - **git**: add hook templates for pre-commit framework
 


### PR DESCRIPTION
This pull request adds git hook templates for pre-push and prepare-commit-msg, and disables the incremental update on bump feature.