### PR TITLE
Fix tmux emacs bindings and bump version to 1.2.1

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 1.2.0
+  version: 1.2.1
   version_scheme: semver

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "golang"
+    commit-message:
+      prefix: "fix(deps)"

--- a/.github/workflows/verBumpChkr.yml
+++ b/.github/workflows/verBumpChkr.yml
@@ -1,0 +1,26 @@
+name: Version Bump Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+env:
+  FILE_PATH: '.cz.yaml'                                     # Path to file with version string
+  VERSION_PATTERN: 'version: [0-9]\+\.[0-9]\+\.[0-9]\+'     # Version string regex pattern
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      with:
+        fetch-depth: 2
+    - name: Check if Version String is Updated
+      run: |
+        if git diff -U0 --diff-filter 'AM' -r HEAD^1 HEAD -- "$FILE_PATH" | grep -q "$VERSION_PATTERN"; then
+          echo "##### ✅ Version updated in $FILE_PATH" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "##### ❌ Version NOT updated in $FILE_PATH" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.1 (2024-03-09)
+
+### Fix
+
+- **tmux**: enforce emacs bindings
+
 ## v1.2.0 (2024-03-08)
 
 ### Feature

--- a/omz/env.zsh
+++ b/omz/env.zsh
@@ -7,6 +7,9 @@ export TERM='xterm-256color'
 # auto accept and run autosuggest
 bindkey '^ ' autosuggest-execute
 
+# enforce emacs keybindings
+bindkey -e
+
 # start ssh-agent(12hr lifetime) if its not running and then add keys
 ssh-add -l &>/dev/null
 if [[ "$?" == 2 ]]; then

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -13,6 +13,10 @@ set -g history-limit 10000    # Bigger history
 set -g default-shell /bin/zsh
 set -g default-terminal "screen-256color"
 
+# enforce emacs key bindings
+set -g mode-keys emacs
+set -g status-keys emacs
+
 # BEGIN BINDINGS
 bind -n M-Left select-pane -L
 bind -n M-Right select-pane -R


### PR DESCRIPTION
This pull request fixes the issue with tmux not enforcing emacs keybindings. Additionally, it bumps the version from 1.2.0 to 1.2.1.