### PR TITLE
Update tmux keybindings and add plugins

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 1.2.1
+  version: 1.3.0
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.3.0 (2024-03-09)
+
+### Feature
+
+- **tmux**: add tmux-logging plugin
+- **tmux**: add tmux-pain-control plugin and remove redundant bindings
+- **tmux**: change horizontal split keybinding from | to +
+- **tmux**: add keybinding to toggle pane input synchronization
+
 ## v1.2.1 (2024-03-09)
 
 ### Fix

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -33,6 +33,7 @@ bind-key X set-window-option synchronize-panes\; display-message "synchronize-pa
 
 # BEGIN PLUGINS
 set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-logging'
 set -g @plugin 'tmux-plugins/tmux-pain-control'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-yank'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -24,19 +24,16 @@ bind -n M-Up select-pane -U
 bind -n M-Down select-pane -D
 bind -n S-Left  previous-window
 bind -n S-Right next-window
-bind + split-window -h
-bind - split-window -v
-bind-key J resize-pane -D 5
-bind-key K resize-pane -U 5
-bind-key H resize-pane -L 5
-bind-key L resize-pane -R 5
 unbind '"'
+bind + split-window -h
 unbind %
+bind - split-window -v
 bind-key X set-window-option synchronize-panes\; display-message "synchronize-panes is now #{?pane_synchronized,on,off}"
 # END BINDINGS
 
 # BEGIN PLUGINS
 set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-pain-control'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'dracula/tmux-dracula'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -24,7 +24,7 @@ bind -n M-Up select-pane -U
 bind -n M-Down select-pane -D
 bind -n S-Left  previous-window
 bind -n S-Right next-window
-bind | split-window -h
+bind + split-window -h
 bind - split-window -v
 bind-key J resize-pane -D 5
 bind-key K resize-pane -U 5

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -32,6 +32,7 @@ bind-key H resize-pane -L 5
 bind-key L resize-pane -R 5
 unbind '"'
 unbind %
+bind-key X set-window-option synchronize-panes\; display-message "synchronize-panes is now #{?pane_synchronized,on,off}"
 # END BINDINGS
 
 # BEGIN PLUGINS


### PR DESCRIPTION
This pull request updates the tmux keybindings to include a new keybinding for toggling pane input synchronization. It also changes the horizontal split keybinding from "|" to "+". Additionally, it adds the tmux-pain-control and tmux-logging plugins to enhance the tmux functionality.