### PR TITLE
move countdown, log_cmd, & pprint to autoload functions

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.0.0
+  version: 2.1.0
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v2.1.0 (2024-12-17)
+
+### Feature
+
+- **omz**: move countdown, log_cmd, & pprint to autoload functions
+- **omz**: add warp directory plugin
+- **omz**: update zshrc to current template
+- **omz**: add colors: purple, pink, orange, and grey
+
+### Fix
+
+- **omz**: rename git-pr-check, git-tag-semver, and install-kubectl with underscores per posix standard
+
+### Refactor
+
+- **omz**: replace git_pr_check echo commands using tput with pprint
+
 ## v2.0.0 (2024-12-15)
 
 ### BREAKING CHANGE

--- a/omz/configure.sh
+++ b/omz/configure.sh
@@ -32,6 +32,7 @@ fi
 
 ln -sf "${DOTFILES_LOCATION}/omz/aliases.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/aliases.zsh"
 ln -sf "${DOTFILES_LOCATION}/omz/env.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/env.zsh"
+ln -sf --no-dereference "${DOTFILES_LOCATION}/omz/functions" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/functions"
 ln -sf "${DOTFILES_LOCATION}/omz/functions.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/functions.zsh"
 ln -sf "${DOTFILES_LOCATION}/omz/variables.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/variables.zsh"
 ln -sf "${DOTFILES_LOCATION}/omz/zshrc" "${HOME}/.zshrc"

--- a/omz/functions.zsh
+++ b/omz/functions.zsh
@@ -7,7 +7,7 @@
 # Outputs:
 #   Writes any existing GitHub pull requests to stdout
 #######################################
-function git-pr-check() {
+function git_pr_check() {
   if [[ $1 == "--help" || $1 == "-h" || $1 == "-?" ]]; then
     echo "Usage: git-pr-check [ --help ]"
     echo -e "Purpose: check child directories for pull requests"
@@ -49,7 +49,7 @@ function git-pr-check() {
 # Outputs:
 #   Writes the latest tag, the new tag, and the floating tags (if requested) to stdout
 #######################################
-function git-tag-semver() {
+function git_tag_semver() {
   if [[ $1 == "--help" || $1 == "-h" || $1 == "-?" ]]; then
     echo "Usage: git-tag-semver [ major | minor | patch ] [float] [push] [--help]"
     echo -e "Purpose: semantically tag a git repository"
@@ -117,7 +117,7 @@ function git-tag-semver() {
 # Arguments:
 #   $1 - the version of kubectl to install, defaults to the latest version
 #######################################
-function install-kubectl() {
+function install_kubectl() {
   local version=""
   # handle -h or --help flags
   if [[ $1 == "--help" || $1 == "-h" || $1 == "-?" ]]; then

--- a/omz/functions.zsh
+++ b/omz/functions.zsh
@@ -1,21 +1,6 @@
 # functions
 
 #######################################
-# countdown timer
-# Arguments:
-#   $1 - the number of seconds to countdown
-#######################################
-function countdown () {
-    local seconds=${1}
-    while [ "$seconds" -gt 0 ]; do
-       echo -ne "waiting: ${seconds}\r"
-       sleep 1
-       : $((seconds--))
-    done
-}
-
-
-#######################################
 # check child directories for pull requests using the GitHub CLI
 # Arguments:
 #   None
@@ -178,50 +163,6 @@ function joincsv () {
   else
     join -t, -a1 --header --nocheck-order <(cat <(head -n1 "$1") <(sed 1d "$1" | sort) | sed 's/\r//') <(cat <(head -n1 "$2") <(sed 1d "$2"| sort) | sed 's/\r//')
   fi
-}
-
-
-#######################################
-# log a shell command, its stdout, and stderr to a file
-# Globals:
-#   CMD_LOG_FILE - the file to log the command and its output to
-# Arguments:
-#   $* - the command to execute
-# Outputs:
-#   Writes the command and its output to the log file and stdout
-#######################################
-function log-cmd () {
-    local header="####################################################\n"
-
-    # check if log file has been named
-    if [ -z "${CMD_LOG_FILE}" ]; then
-      local CMD_LOG_FILE="/tmp/command.log"
-      echo "No log file specified, using default: ${CMD_LOG_FILE}\n"
-    fi
-
-    {
-      printf ${header}
-      printf "\`%s\` executed at $(date '+%Y-%m-%d %H:%M:%S')\n" "$*"
-      printf ${header}
-      "$@"
-      printf "\n"
-    } 2>&1 | tee -a "${CMD_LOG_FILE}"
-}
-
-
-#######################################
-# Pretty print a string with styles
-# Arguments:
-#   $1 - text to print (required)
-#   $@ - styles to apply (optional)
-# Outputs:
-#   Writes the text to stdout with the styles applied
-#######################################
-function pprint() {
-  local text="$1"
-  shift
-  local styles="$*"
-  printf '%b%s%b\n' "${styles// /}" "$text" "$txReset"
 }
 
 

--- a/omz/functions.zsh
+++ b/omz/functions.zsh
@@ -18,22 +18,22 @@ function git_pr_check() {
   for dir in $(find . -mindepth 1 -maxdepth 1 -type d -printf '%P\n'); do
     cd "$dir"
     # has a .git directory
-    if [ -d .git ]; then
+    if [ -d .git -o -d refs ]; then
       # has a GitHub remote
       if git remote -v | grep -iq github; then
         echo
-        echo "$(tput setaf 2)🟢 $dir$(tput sgr0)"
+        pprint "🟢 ${dir}" $fgGreen
         gh pr list
         echo
       # does not have a GitHub remote
       else
-        echo "$(tput setaf 214)🟠 $dir, not using GitHub$(tput sgr0)"
+        pprint "🟠 ${dir}, not using GitHub" $fgYellow
         cd ..
         continue
       fi
     # does not have a .git directory
     else
-      echo "$(tput setaf 7)➖ $dir, not a git repo$(tput sgr0)"
+      pprint "➖ $dir, not a git repo"
     fi
     cd ..
   done
@@ -41,7 +41,7 @@ function git_pr_check() {
 
 
 #######################################
-# add signed & annontated semantic version tags(either single or floating tags) to a git repository
+# add signed & annotated semantic version tags(either single or floating tags) to a git repository
 # Arguments:
 #   $1 - major|minor|patch (required)
 #   $2 - 'float' to add floating tags, null otherwise

--- a/omz/functions/countdown
+++ b/omz/functions/countdown
@@ -1,0 +1,12 @@
+#######################################
+# name: countdown
+# countdown timer
+# Arguments:
+#   $1 - the number of seconds to countdown
+#######################################
+local seconds=${1}
+while [ "$seconds" -gt 0 ]; do
+  echo -ne "waiting: ${seconds}\r"
+  sleep 1
+  : $((seconds--))
+done

--- a/omz/functions/log_cmd
+++ b/omz/functions/log_cmd
@@ -1,0 +1,25 @@
+#######################################
+# name: log_cmd
+# log a shell command, its stdout, and stderr to a file
+# Globals:
+#   CMD_LOG_FILE - the file to log the command and its output to
+# Arguments:
+#   $* - the command to execute
+# Outputs:
+#   Writes the command and its output to the log file and stdout
+#######################################
+local header="####################################################\n"
+
+# check if log file has been named
+if [ -z "${CMD_LOG_FILE}" ]; then
+  local CMD_LOG_FILE="/tmp/command.log"
+  echo "No log file specified, using default: ${CMD_LOG_FILE}\n"
+fi
+
+{
+  printf ${header}
+  printf "\`%s\` executed at $(date '+%Y-%m-%d %H:%M:%S')\n" "$*"
+  printf ${header}
+  "$@"
+  printf "\n"
+} 2>&1 | tee -a "${CMD_LOG_FILE}"

--- a/omz/functions/log_cmd_d
+++ b/omz/functions/log_cmd_d
@@ -1,0 +1,17 @@
+#######################################
+# name: log_cmd_d
+# log a shell command, its stdout, and stderr to a file
+# Arguments:
+#   $* - the command to execute
+# Outputs:
+#   Writes the command and its output to a timestamped log file and stdout
+#######################################
+local header="####################################################\n"
+
+{
+  printf ${header}
+  printf "Command executed: %s\n\n" "$*"
+  printf ${header}
+  "$@"
+  printf "\n"
+} 2>&1 | tee "/tmp/cmd-$(date '+%Y_%m_%d_%H-%M-%S').log"

--- a/omz/functions/pprint
+++ b/omz/functions/pprint
@@ -1,0 +1,13 @@
+#######################################
+# name: pprint
+# Pretty print a string with styles
+# Arguments:
+#   $1 - text to print (required)
+#   $* - styles to apply (optional)
+# Outputs:
+#   Writes the text to stdout with the styles applied
+#######################################
+local text="$1"
+shift
+local styles="$*"
+printf '%b%s%b\n' "${styles// /}" "$text" "$txReset"

--- a/omz/variables.zsh
+++ b/omz/variables.zsh
@@ -1,29 +1,41 @@
 # background color using ANSI escape
-[ -z $bgBlack ]     && declare -r bgBlack=$(tput setab 0)   && export bgBlack       # black
-[ -z $bgRed ]       && declare -r bgRed=$(tput setab 1)     && export bgRed         # red
-[ -z $bgGreen ]     && declare -r bgGreen=$(tput setab 2)   && export bgGreen       # green
-[ -z $bgYellow ]    && declare -r bgYellow=$(tput setab 3)  && export bgYellow      # yellow
-[ -z $bgBlue ]      && declare -r bgBlue=$(tput setab 4)    && export bgBlue        # blue
-[ -z $bgMagenta ]   && declare -r bgMagenta=$(tput setab 5) && export bgMagenta     # magenta
-[ -z $bgCyan ]      && declare -r bgCyan=$(tput setab 6)    && export bgCyan        # cyan
-[ -z $bgWhite ]     && declare -r bgWhite=$(tput setab 7)   && export bgWhite       # white
+[ -z $bgBlack ]     && declare -r bgBlack=$(tput setab 0)    && export bgBlack       # black
+[ -z $bgRed ]       && declare -r bgRed=$(tput setab 1)      && export bgRed         # red
+[ -z $bgGreen ]     && declare -r bgGreen=$(tput setab 2)    && export bgGreen       # green
+[ -z $bgYellow ]    && declare -r bgYellow=$(tput setab 3)   && export bgYellow      # yellow
+[ -z $bgBlue ]      && declare -r bgBlue=$(tput setab 4)     && export bgBlue        # blue
+[ -z $bgMagenta ]   && declare -r bgMagenta=$(tput setab 5)  && export bgMagenta     # magenta
+[ -z $bgCyan ]      && declare -r bgCyan=$(tput setab 6)     && export bgCyan        # cyan
+[ -z $bgWhite ]     && declare -r bgWhite=$(tput setab 7)    && export bgWhite       # white
+[ -z $bgPurple ]    && declare -r bgPurple=$(tput setab 99)  && export bgPurple      # purple
+[ -z $bgPink ]      && declare -r bgPink=$(tput setab 171)   && export bgPink        # pink
+[ -z $bgOrange ]    && declare -r bgOrange=$(tput setab 172) && export bgOrange      # orange
+[ -z $bgDkGrey ]    && declare -r bgDkGrey=$(tput setab 237) && export bgDkGrey      # dark grey
+[ -z $bgGrey ]      && declare -r bgGrey=$(tput setab 243)   && export bgGrey        # grey
+[ -z $bgLtGrey ]    && declare -r bgLtGrey=$(tput setab 249) && export bgLtGrey      # light grey
 
 # foreground color using ANSI escape
-[ -z $fgBlack ]     && declare -r fgBlack=$(tput setaf 0)   && export fgBlack       # black
-[ -z $fgRed ]       && declare -r fgRed=$(tput setaf 1)     && export fgRed         # red
-[ -z $fgGreen ]     && declare -r fgGreen=$(tput setaf 2)   && export fgGreen       # green
-[ -z $fgYellow ]    && declare -r fgYellow=$(tput setaf 3)  && export fgYellow      # yellow
-[ -z $fgBlue ]      && declare -r fgBlue=$(tput setaf 4)    && export fgBlue        # blue
-[ -z $fgMagenta ]   && declare -r fgMagenta=$(tput setaf 5) && export fgMagenta     # magenta
-[ -z $fgCyan ]      && declare -r fgCyan=$(tput setaf 6)    && export fgCyan        # cyan
-[ -z $fgWhite ]     && declare -r fgWhite=$(tput setaf 7)   && export fgWhite       # white
+[ -z $fgBlack ]     && declare -r fgBlack=$(tput setaf 0)    && export fgBlack       # black
+[ -z $fgRed ]       && declare -r fgRed=$(tput setaf 1)      && export fgRed         # red
+[ -z $fgGreen ]     && declare -r fgGreen=$(tput setaf 2)    && export fgGreen       # green
+[ -z $fgYellow ]    && declare -r fgYellow=$(tput setaf 3)   && export fgYellow      # yellow
+[ -z $fgBlue ]      && declare -r fgBlue=$(tput setaf 4)     && export fgBlue        # blue
+[ -z $fgMagenta ]   && declare -r fgMagenta=$(tput setaf 5)  && export fgMagenta     # magenta
+[ -z $fgCyan ]      && declare -r fgCyan=$(tput setaf 6)     && export fgCyan        # cyan
+[ -z $fgWhite ]     && declare -r fgWhite=$(tput setaf 7)    && export fgWhite       # white
+[ -z $fgPurple ]    && declare -r fgPurple=$(tput setaf 99)  && export fgPurple      # purple
+[ -z $fgPink ]      && declare -r fgPink=$(tput setaf 171)   && export fgPink        # pink
+[ -z $fgOrange ]    && declare -r fgOrange=$(tput setaf 172) && export fgOrange      # orange
+[ -z $fgDkGrey ]    && declare -r fgDkGrey=$(tput setaf 237) && export fgDkGrey      # dark grey
+[ -z $fgGrey ]      && declare -r fgGrey=$(tput setaf 243)   && export fgGrey        # grey
+[ -z $fgLtGrey ]    && declare -r fgLtGrey=$(tput setaf 249) && export fgLtGrey      # light grey
 
 # text attributes using ANSI escape
-[ -z $txBold ]      && declare -r txBold=$(tput bold)       && export txBold        # bold
-[ -z $txHalf ]      && declare -r txHalf=$(tput dim)        && export txHalf        # half-bright
-[ -z $txUnderline ] && declare -r txUnderline=$(tput smul)  && export txUnderline   # underline
-[ -z $txEndUnder ]  && declare -r txEndUnder=$(tput rmul)   && export txEndUnder    # exit underline
-[ -z $txReverse ]   && declare -r txReverse=$(tput rev)     && export txReverse     # reverse
-[ -z $txStandout ]  && declare -r txStandout=$(tput smso)   && export txStandout    # standout
-[ -z $txEndStand ]  && declare -r txEndStand=$(tput rmso)   && export txEndStand    # exit standout
-[ -z $txReset ]     && declare -r txReset=$(tput sgr0)      && export txReset       # reset attributes
+[ -z $txBold ]      && declare -r txBold=$(tput bold)        && export txBold        # bold
+[ -z $txHalf ]      && declare -r txHalf=$(tput dim)         && export txHalf        # half-bright
+[ -z $txUnderline ] && declare -r txUnderline=$(tput smul)   && export txUnderline  # underline
+[ -z $txEndUnder ]  && declare -r txEndUnder=$(tput rmul)    && export txEndUnder   # exit underline
+[ -z $txReverse ]   && declare -r txReverse=$(tput rev)      && export txReverse    # reverse
+[ -z $txStandout ]  && declare -r txStandout=$(tput smso)    && export txStandout    # standout
+[ -z $txEndStand ]  && declare -r txEndStand=$(tput rmso)    && export txEndStand    # exit standout
+[ -z $txReset ]     && declare -r txReset=$(tput sgr0)       && export txReset       # reset attributes

--- a/omz/zshrc
+++ b/omz/zshrc
@@ -89,6 +89,7 @@ plugins=(
   kubectl
   ssh-agent
   tmux
+  wd
   zsh-autosuggestions
   zsh-syntax-highlighting
 )

--- a/omz/zshrc
+++ b/omz/zshrc
@@ -134,5 +134,10 @@ export LC_CTYPE=en_US.UTF-8
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
+# autoload from zsh custom functions directory
+for file in $ZSH_CUSTOM/functions/*; do
+  autoload -Uz $file
+done
+
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [ ! -f ~/.p10k.zsh ] || source ~/.p10k.zsh

--- a/omz/zshrc
+++ b/omz/zshrc
@@ -11,33 +11,38 @@ export PATH=$HOME/.local/bin:$PATH
 # Path to your oh-my-zsh installation.
 export ZSH="${HOME}/.oh-my-zsh"
 
-# Set name of the theme to load. Optionally, if you set this to "random"
-# it'll load a random theme each time that oh-my-zsh is loaded.
-# See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
+# Set name of the theme to load --- if set to "random", it will
+# load a random theme each time Oh My Zsh is loaded, in which case,
+# to know which specific one was loaded, run: echo $RANDOM_THEME
+# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
 ZSH_THEME="powerlevel10k/powerlevel10k"
+
+# Set list of themes to pick from when loading at random
+# Setting this variable when ZSH_THEME=random will cause zsh to load
+# a theme from this variable instead of looking in $ZSH/themes/
+# If set to an empty array, this variable will have no effect.
+# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
 
 # powerlevel10k
 DEFAULT_USER=$(whoami)
 
-# Set list of themes to load
-# Setting this variable when ZSH_THEME=random
-# cause zsh load theme from this variable instead of
-# looking in ~/.oh-my-zsh/themes/
-# An empty array have no effect
-# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
-
 # Uncomment the following line to use case-sensitive completion.
 # CASE_SENSITIVE="true"
 
-# Uncomment the following line to use hyphen-insensitive completion. Case
-# sensitive completion must be off. _ and - will be interchangeable.
+# Uncomment the following line to use hyphen-insensitive completion.
+# Case-sensitive completion must be off. _ and - will be interchangeable.
 # HYPHEN_INSENSITIVE="true"
 
-# Uncomment the following line to disable bi-weekly auto-update checks.
-# DISABLE_AUTO_UPDATE="true"
+# Uncomment one of the following lines to change the auto-update behavior
+# zstyle ':omz:update' mode disabled  # disable automatic updates
+# zstyle ':omz:update' mode auto      # update automatically without asking
+zstyle ':omz:update' mode reminder  # just remind me to update when it's time
 
 # Uncomment the following line to change how often to auto-update (in days).
-# export UPDATE_ZSH_DAYS=13
+zstyle ':omz:update' frequency 30
+
+# Uncomment the following line if pasting URLs and other text is messed up.
+# DISABLE_MAGIC_FUNCTIONS="true"
 
 # Uncomment the following line to disable colors in ls.
 # DISABLE_LS_COLORS="true"
@@ -49,6 +54,9 @@ DEFAULT_USER=$(whoami)
 # ENABLE_CORRECTION="true"
 
 # Uncomment the following line to display red dots whilst waiting for completion.
+# You can also set it to another string to have that shown instead of the default red dots.
+# e.g. COMPLETION_WAITING_DOTS="%F{yellow}waiting...%f"
+# Caution: this setting can cause issues with multiline prompts in zsh < 5.7.1 (see #5765)
 # COMPLETION_WAITING_DOTS="true"
 
 # Uncomment the following line if you want to disable marking untracked files
@@ -58,14 +66,18 @@ DEFAULT_USER=$(whoami)
 
 # Uncomment the following line if you want to change the command execution time
 # stamp shown in the history command output.
-# The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# You can set one of the optional three formats:
+# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
+# or set a custom format using the strftime function format specifications,
+# see 'man strftime' for details.
 # HIST_STAMPS="mm/dd/yyyy"
 
 # Would you like to use another custom folder than $ZSH/custom?
 # ZSH_CUSTOM=/path/to/new-custom-folder
 
-# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+# Which plugins would you like to load?
+# Standard plugins can be found in $ZSH/plugins/
+# Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(
@@ -103,18 +115,18 @@ export LC_CTYPE=en_US.UTF-8
 # if [[ -n $SSH_CONNECTION ]]; then
 #   export EDITOR='vim'
 # else
-#   export EDITOR='mvim'
+#   export EDITOR='nvim'
 # fi
 
 # Compilation flags
-# export ARCHFLAGS="-arch x86_64"
+# export ARCHFLAGS="-arch $(uname -m)"
 
-# ssh
-# export SSH_KEY_PATH="~/.ssh/rsa_id"
-
-# Set personal aliases, overriding those provided by oh-my-zsh libs,
-# plugins, and themes. Aliases can be placed here, though oh-my-zsh
-# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# Set personal aliases, overriding those provided by Oh My Zsh libs,
+# plugins, and themes. Aliases can be placed here, though Oh My Zsh
+# users are encouraged to define aliases within a top-level file in
+# the $ZSH_CUSTOM folder, with .zsh extension. Examples:
+# - $ZSH_CUSTOM/aliases.zsh
+# - $ZSH_CUSTOM/macos.zsh
 # For a full list of active aliases, run `alias`.
 #
 # Example aliases


### PR DESCRIPTION
This pull request includes several updates and improvements to the `omz` configuration and functions.

### New Features:
* Added new background and foreground colors (purple, pink, orange, and grey) in `omz/variables.zsh`. [[1]](diffhunk://#diff-495aa0bd371bb0d605d2f131e422946287d7f98ea24c67faadbffae51773b5bbR10-R15) [[2]](diffhunk://#diff-495aa0bd371bb0d605d2f131e422946287d7f98ea24c67faadbffae51773b5bbR26-R31)
* Added the `warp directory` plugin and updated `zshrc` to the latest template.
* Added autoload functionality for custom functions in `omz/zshrc`.

### Bug Fixes:
* Renamed several functions to use underscores per POSIX standard in `omz/functions.zsh`. [[1]](diffhunk://#diff-8fb54c450333be79193e6e3c09360e6e997d25a9b0dcca1eb866f0b2fa6e97caL3-R10) [[2]](diffhunk://#diff-8fb54c450333be79193e6e3c09360e6e997d25a9b0dcca1eb866f0b2fa6e97caL135-R120) [[3]](diffhunk://#diff-8fb54c450333be79193e6e3c09360e6e997d25a9b0dcca1eb866f0b2fa6e97caL184-L227)
* Updated `git-pr-check` function to recognize directories with either `.git` or `refs` in `omz/functions.zsh`.

### Refactoring:
* Moved `countdown`, `log_cmd`, and `pprint` functions to separate files in `omz/functions`. [[1]](diffhunk://#diff-1d800cc2e69f044913a95a729f83fc68e9df94541b095cfd5160aba45994eb50R1-R12) [[2]](diffhunk://#diff-3ecbdb4dc62864f293fbdca9b0867deb82401b63efc005765257479425d96d79R1-R25) [[3]](diffhunk://#diff-09305870ba6e8ee7220d9a62204227ff61964afe57d01a5db7a9c7ec723e6e43R1-R17) [[4]](diffhunk://#diff-980d42d68cbec0dedcb2ce23fe7da5aaa205b7fbd7245eb2626d16d2bf3c285dR1-R13)
* Replaced `tput` commands with `pprint` in `omz/functions.zsh`.