### PR TITLE
add install_it & get_release functions

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.1.0
+  version: 2.2.0
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v2.2.0 (2024-12-22)
+
+### Feature
+
+- **omz**: add get_release function to download GitHub releases with option for listing available versions
+- **omz**: add install_it function for installing executables from ~/install to /usr/local/bin using install command
+- **omz**: add option to suppress trailing newline in output to pprint function
+- **omz**: allow escape squences like new line in pprint message parameter
+
+### Refactor
+
+- **omz**: properly quote header variables
+- **omz**: move function docs from comments to runtime help message for countdown, log_cmd, log_cmd_d, and pprint
+
 ## v2.1.0 (2024-12-17)
 
 ### Feature

--- a/omz/functions/countdown
+++ b/omz/functions/countdown
@@ -1,9 +1,17 @@
 #######################################
-# name: countdown
-# countdown timer
-# Arguments:
-#   $1 - the number of seconds to countdown
+# countdown
 #######################################
+if [ $# -eq 0 ]; then
+  fold -w $(tput cols) -s <<EOF
+Usage: countdown <seconds>
+Countdown timer that prints the remaining seconds.
+
+Arguments:
+  seconds  The number of seconds to countdown
+EOF
+  return 0
+fi
+
 local seconds=${1}
 while [ "$seconds" -gt 0 ]; do
   echo -ne "waiting: ${seconds}\r"

--- a/omz/functions/get_release
+++ b/omz/functions/get_release
@@ -1,0 +1,255 @@
+#######################################
+# get_release
+#######################################
+if [ $# -eq 0 ]; then
+  fold -w $(tput cols) -s <<EOF
+Usage: get_release {--owner <owner_name> --repo <repo_name> | --url <repo_url>} [--version <version>] [--download] [--list]
+Download the latest release or a specific version from a GitHub repo. If --list it will list the last 30 releases and exit. If the downloaded file is an archive, it will be extracted to ~/install.
+
+Options:
+  -o, --owner <owner_name>  GitHub owner name
+  -r, --repo <repo_name>    GitHub repo name
+  -u, --url <repo_url>      GitHub repo URL
+  -d, --download            Download the asset and exit
+  -l, --list                List the last 30 releases
+  -v, --version <version>   version to download
+EOF
+  return 0
+fi
+
+local download=""
+local download_path="$HOME/install"
+local list=""
+local owner=""
+local repo=""
+local url=""
+local version=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o|--owner)
+      if [ "$2" ]; then
+        owner="$2"
+        shift 2
+      else
+        pprint "Error: --owner requires a non-empty argument." "$fgRed" "$txBold"
+        return 1
+      fi
+      ;;
+    --owner=?*)
+      owner=${1#*=} # Delete everything up to "=" and assign the remainder.
+      ;;
+    --owner=)
+      pprint "Error: --owner requires a non-empty argument." "$fgRed" "$txBold"
+      return 1
+      ;;
+    -r|--repo)
+      if [ "$2" ]; then
+        repo="$2"
+        shift 2
+      else
+        pprint "Error: --repo requires a non-empty argument." "$fgRed" "$txBold"
+        return 1
+      fi
+      ;;
+    --repo=?*)
+      repo=${1#*=} # Delete everything up to "=" and assign the remainder.
+      ;;
+    --repo=)
+      pprint "Error: --repo requires a non-empty argument." "$fgRed" "$txBold"
+      return 1
+      ;;
+    -u|--url)
+      if [ "$2" ]; then
+        url="$2"
+        shift 2
+      else
+        pprint "Error: --url requires a non-empty argument." "$fgRed" "$txBold"
+        return 1
+      fi
+      ;;
+    --url=?*)
+      url=${1#*=} # Delete everything up to "=" and assign the remainder.
+      ;;
+    --url=)
+      pprint "Error: --url requires a non-empty argument." "$fgRed" "$txBold"
+      return 1
+      ;;
+    -d|--download)
+      download=true
+      shift
+      ;;
+    -l|--list)
+      list=true
+      shift
+      ;;
+    -v|--version)
+      if [ "$2" ]; then
+        version="$2"
+        shift 2
+      else
+        pprint "Error: --version requires a non-empty argument." "$fgRed" "$txBold"
+        return 1
+      fi
+      ;;
+    --version=?*)
+      release=${1#*=} # Delete everything up to "=" and assign the remainder.
+      ;;
+    --version=)
+      pprint "Error: --version requires a non-empty argument." "$fgRed" "$txBold"
+      return 1
+      ;;
+    --help)
+      pprint "Usage: script.sh [--owner <owner_name> --repo <repo_name> | --url <repo_url>] [-o <owner_name>] [-r <repo_name>]"
+      return 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      pprint "Unknown argument: $1" "$fgRed" "$txBold"
+      return 1
+      ;;
+  esac
+done
+
+if [[ -n "$url" && (-n "$owner" || -n "$repo") ]]; then
+  pprint "Error: --url is mutually exclusive with --owner and --repo." "$fgRed" "$txBold"
+  return 1
+fi
+
+if [[ -z "$url" && ( -z "$owner" || -z "$repo" ) ]]; then
+  pprint "Error: --owner and --repo are required together unless --url is provided." "$fgRed" "$txBold"
+  return 1
+fi
+
+if [ -n "$url" ]; then
+  local extracted=$(echo "$url" | grep -oP 'github\.com/\K[^/]+/[^/]+')
+  if ! [[ "$extracted" =~ .*/.* ]]; then
+    pprint "Error: Invalid GitHub Owner/Repo." "$fgRed" "$txBold"
+    return 1
+  fi
+  owner=$(cut -d'/' -f1 <<< "$extracted")
+  repo=$(cut -d'/' -f2 <<< "$extracted")
+  pprint "Owner: $owner" "$fgBlue"
+  pprint "Repo: $repo" "$fgBlue"
+fi
+
+# test if the repo exists https://github.com/${owner}/${repo}
+if ! curl -s --head --fail "https://github.com/${owner}/${repo}" > /dev/null; then
+  pprint "Error: GitHub repo not found: https://github.com/${owner}/${repo}" "$fgRed" "$txBold"
+  return 1
+fi
+
+if [ -n "$list" ]; then
+  pprint "\nListing last 30 releases..." "$fgOrange"
+  local releases=()
+  while IFS= read -r release; do
+    releases+=("$release")
+  done < <(curl -s https://api.github.com/repos/${owner}/${repo}/releases | jq -r '.[] | "\(.name)"' 2>/dev/null)
+
+  if [ ${#releases[@]} -eq 0 ]; then
+    pprint "Error: No releases found." "$fgRed" "$txBold"
+    return 1
+  fi
+
+  for release in "${releases[@]}"; do
+    pprint " • $release"
+  done
+  return 0
+fi
+
+# if version was not provided, download the latest release, otherwise download the specified version
+if [ -z "$version" ]; then
+  version=$(curl -s https://api.github.com/repos/${owner}/${repo}/releases/latest | jq -r '.tag_name' 2>/dev/null)
+  if [ "$version" = 'null' ]; then
+    pprint "Error: No releases found for: https://github.com/${owner}/${repo}/" "$fgRed" "$txBold"
+    return 1
+  fi
+fi
+
+local assets=()
+while IFS= read -r asset; do
+  # dont add .asc, .json*, .txt, or .sha256 assets to the array
+  case "${asset% *}" in
+    *.asc|*.json*|*.txt|*.sha256)
+      continue
+      ;;
+  esac
+  assets+=("$asset")
+done < <(curl -s https://api.github.com/repos/${owner}/${repo}/releases/tags/${version} | jq -r '.assets[] | "\(.name) \(.browser_download_url)"' 2>/dev/null)
+
+if [ ${#assets[@]} -eq 0 ]; then
+  pprint "Error: No installable assets found for ${owner}/${repo} ${version} at: https://github.com/${owner}/${repo}/releases/tag/${version}" "$fgRed" "$txBold"
+  return 1
+fi
+
+# prompt user with menu to select the asset to download
+local selected=""
+if [ ${#assets[@]} -gt 1 ]; then
+  pprint "\nDownloadable assets for ${version}:" "$fgOrange"
+  local i=1
+  for asset in "${assets[@]}"; do
+    printf ' %3s %s\n' "$i." "${asset% *}"
+    ((i++))
+  done
+  echo -en "\nSelect an asset to download from the list above [1-${#assets[@]}]: "
+  read selected
+  if ! [[ "$selected" =~ ^[0-9]+$ ]] || [ "$selected" -lt 1 ] || [ "$selected" -gt ${#assets[@]} ]; then
+    pprint "\nError: Invalid selection." "$fgRed" "$txBold"
+    return 1
+  fi
+  selected=${assets[$selected]}
+else
+  selected=${assets[0]}
+fi
+
+pprint "\nDownloading ${selected##* } to ${download_path}/${selected% *}" "$fgBlue"
+/usr/bin/curl -s -L -o "${download_path}/${selected% *}" "${selected##* }"
+
+# if curl return code is not 0, then download failed
+if [ $? -ne 0 ]; then
+  pprint "\nError: Download failed." "$fgRed" "$txBold"
+  return 1
+fi
+
+if [ -n "$download" ]; then
+  return 0
+fi
+
+# check if the download file is an archive and extract it
+if [[ "${selected% *}" =~ \.(tar\.gz|tar\.xz|tar|zip)$ ]]; then
+  pprint "Extracting ${selected% *}..." "$fgBlue"
+  case "${selected% *}" in
+    *.tar.gz)
+      tar -xzf "${download_path}/${selected% *}" -C "${download_path}"
+      ;;
+    *.tar.xz)
+      tar -xJf "${download_path}/${selected% *}" -C "${download_path}"
+      ;;
+    *.tar)
+      tar -xf "${download_path}/${selected% *}" -C "${download_path}"
+      ;;
+    *.zip)
+      unzip -q "${download_path}/${selected% *}" -d "${download_path}"
+      ;;
+  esac
+fi
+
+# if tar return code is not 0, then download failed
+if [ $? -ne 0 ]; then
+  pprint "\nError: Extracting ${selected% *} failed." "$fgRed" "$txBold"
+  return 1
+else
+  pprint "Files extracted successfully, removing ${selected% *}..." "$fgBlue"
+  rm -f "${download_path}/${selected% *}"
+fi
+
+# list the extracted files
+pprint "\nExtracted files:" "$fgOrange"
+for file in "${download_path}"/*; do
+  pprint " • $(basename "$file")"
+done
+
+return 0

--- a/omz/functions/install_it
+++ b/omz/functions/install_it
@@ -1,0 +1,39 @@
+#######################################
+# install_it
+#######################################
+if [ $# -eq 0 ]; then
+  fold -w $(tput cols) -s <<'EOF'
+Usage: install_it <source_file> [target_file]
+Uses the install command to install an executable from ~/install to /usr/local/bin by default.
+
+Arguments:
+  source_file - executable to install. The script assumes it is in ~/install if a path is not provided.
+  target_file - target filename. If not provided, the source filename is used. If a path is not provided, the executable is installed in /usr/local/bin.
+EOF
+  return 0
+fi
+
+# if the source file contains a path, use it, otherwise assume it is in ~/install
+if [[ "$1" == */* ]]; then
+  local source_file=${1}
+else
+  local source_file="${HOME}/install/${1}"
+fi
+
+# ensure the source file exists
+if [ ! -f "${source_file}" ]; then
+  pprint "Error: ${source_file} not found" "$fgRed" "$txBold"
+  return 1
+fi
+
+# if the target filename is provided and contains a path, use it, otherwise install in /usr/local/bin
+if [[ "$2" == */* ]]; then
+  local target_file="${2}"
+elif [ -n "$2" ]; then
+  local target_file="/usr/local/bin/${2}"
+else
+  local target_file="/usr/local/bin/$(basename ${source_file})"
+fi
+
+sudo install -v -m 755 -o root -g root "${source_file}" "${target_file}"
+[ $? -eq 0 ] && pprint "Successfully installed: ${target_file}" "$fgGreen" || pprint "Error: Failed to install: ${source_file}" "$fgRed" "$txBold"

--- a/omz/functions/log_cmd
+++ b/omz/functions/log_cmd
@@ -24,9 +24,9 @@ if [ -z "${CMD_LOG_FILE}" ]; then
 fi
 
 {
-  printf ${header}
+  printf "${header}"
   printf "\`%s\` executed at $(date '+%Y-%m-%d %H:%M:%S')\n" "$*"
-  printf ${header}
+  printf "${header}"
   "$@"
   printf "\n"
 } 2>&1 | tee -a "${CMD_LOG_FILE}"

--- a/omz/functions/log_cmd
+++ b/omz/functions/log_cmd
@@ -1,13 +1,20 @@
 #######################################
-# name: log_cmd
-# log a shell command, its stdout, and stderr to a file
-# Globals:
-#   CMD_LOG_FILE - the file to log the command and its output to
-# Arguments:
-#   $* - the command to execute
-# Outputs:
-#   Writes the command and its output to the log file and stdout
+# log_cmd
 #######################################
+if [ $# -eq 0 ]; then
+  fold -w $(tput cols) -s <<EOF
+Usage: log_cmd <command>
+Log a shell command, its stdout, and stderr to a file.
+
+Variables:
+  CMD_LOG_FILE - the file to log the command and its output to (default: /tmp/command.log)
+
+Arguments:
+  command - command to execute and log
+EOF
+  return 0
+fi
+
 local header="####################################################\n"
 
 # check if log file has been named

--- a/omz/functions/log_cmd_d
+++ b/omz/functions/log_cmd_d
@@ -15,9 +15,9 @@ fi
 local header="####################################################\n"
 
 {
-  printf ${header}
+  printf "${header}"
   printf "Command executed: %s\n\n" "$*"
-  printf ${header}
+  printf "${header}"
   "$@"
   printf "\n"
 } 2>&1 | tee "/tmp/cmd-$(date '+%Y_%m_%d_%H-%M-%S').log"

--- a/omz/functions/log_cmd_d
+++ b/omz/functions/log_cmd_d
@@ -1,11 +1,17 @@
 #######################################
-# name: log_cmd_d
-# log a shell command, its stdout, and stderr to a file
-# Arguments:
-#   $* - the command to execute
-# Outputs:
-#   Writes the command and its output to a timestamped log file and stdout
+# log_cmd_d
 #######################################
+if [ $# -eq 0 ]; then
+  fold -w $(tput cols) -s <<EOF
+Usage: log_cmd_d <command>
+Log a shell command, its stdout, and stderr to a timestamped log file.
+
+Arguments:
+  command - command to execute and log
+EOF
+  return 0
+fi
+
 local header="####################################################\n"
 
 {

--- a/omz/functions/pprint
+++ b/omz/functions/pprint
@@ -2,12 +2,29 @@
 # name: pprint
 # Pretty print a string with styles
 # Arguments:
+#   -n - do not output the trailing newline (optional)
 #   $1 - text to print (required)
 #   $* - styles to apply (optional)
 # Outputs:
 #   Writes the text to stdout with the styles applied
 #######################################
+# handle options
+local newline="\n"
+while [[ "$1" == -* ]]; do
+  case "$1" in
+    -n)
+      newline=""
+      ;;
+    *)
+      ;;
+  esac
+  shift
+done
+
+# handle arguments
 local text="$1"
 shift
 local styles="$*"
-printf '%b%b%b\n' "${styles// /}" "$text" "$txReset"
+
+# Print with or without newline
+printf '%b%b%b%b' "${styles// /}" "$text" "$txReset" "$newline"

--- a/omz/functions/pprint
+++ b/omz/functions/pprint
@@ -1,13 +1,23 @@
 #######################################
-# name: pprint
-# Pretty print a string with styles
-# Arguments:
-#   -n - do not output the trailing newline (optional)
-#   $1 - text to print (required)
-#   $* - styles to apply (optional)
-# Outputs:
-#   Writes the text to stdout with the styles applied
+# pprint
 #######################################
+if [ $# -eq 0 ]; then
+  fold -w $(tput cols) -s <<'EOF'
+Usage: pprint [-n] <text> [styles]
+Pretty print a string with color or text decorations. The text is written to stdout with the styles applied.
+
+The styles are optional escape sequences stored in environment variables that begin with "bg" or "fg" followed by a color, or "tx" follow by a text decoration. For example, "$fgRed" sets the foreground color to red, "$bgBlue" sets the background color to blue, and "$txBold" sets the text to bold.
+
+Options:
+  -n  do not output the trailing newline
+
+Arguments:
+  text   text to print(will parse escape sequences).
+  styles styles to apply
+EOF
+  return 0
+fi
+
 # handle options
 local newline="\n"
 while [[ "$1" == -* ]]; do

--- a/omz/functions/pprint
+++ b/omz/functions/pprint
@@ -10,4 +10,4 @@
 local text="$1"
 shift
 local styles="$*"
-printf '%b%s%b\n' "${styles// /}" "$text" "$txReset"
+printf '%b%b%b\n' "${styles// /}" "$text" "$txReset"


### PR DESCRIPTION
New features:

* [`omz/functions/get_release`](diffhunk://#diff-398970f080c0f62c935eba7e36da5e26b2294b453a73ae4152f3e32d3530da14R1-R256): Added a new function to download GitHub releases with options for listing available versions and extracting archives.
* [`omz/functions/install_it`](diffhunk://#diff-bd1d94eccacfbf011c04b548e478ab25efdd5136c06daf604f6fa3592106857cR1-R39): Added a new function to install executables from `~/install` to `/usr/local/bin` using the install command.

Enhancements to existing functions:

* [`omz/functions/countdown`](diffhunk://#diff-1d800cc2e69f044913a95a729f83fc68e9df94541b095cfd5160aba45994eb50L2-R14): Updated to include a usage message when no arguments are provided.
* [`omz/functions/log_cmd*`](diffhunk://#diff-3ecbdb4dc62864f293fbdca9b0867deb82401b63efc005765257479425d96d79L2-R17): Updated to include a usage message and properly quote header variables. [[1]](diffhunk://#diff-3ecbdb4dc62864f293fbdca9b0867deb82401b63efc005765257479425d96d79L2-R17) [[2]](diffhunk://#diff-3ecbdb4dc62864f293fbdca9b0867deb82401b63efc005765257479425d96d79L20-R29)
* [`omz/functions/pprint`](diffhunk://#diff-980d42d68cbec0dedcb2ce23fe7da5aaa205b7fbd7245eb2626d16d2bf3c285dL2-R43): Added an option to suppress the trailing newline in the output and updated the usage message.