### PR TITLE
Properly nest archive error handling inside the archive conditional

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.2.0
+  version: 2.2.1
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.2.1 (2024-12-24)
+
+### Fix
+
+- **omz**: properly nest archive error handling inside archive conditional and generalize file listing
+
 ## v2.2.0 (2024-12-22)
 
 ### Feature

--- a/omz/functions/get_release
+++ b/omz/functions/get_release
@@ -235,19 +235,19 @@ if [[ "${selected% *}" =~ \.(tar\.gz|tar\.xz|tar|zip)$ ]]; then
       unzip -q "${download_path}/${selected% *}" -d "${download_path}"
       ;;
   esac
+
+  # if tar return code is not 0, then download failed
+  if [ $? -ne 0 ]; then
+    pprint "\nError: Extracting ${selected% *} failed." "$fgRed" "$txBold"
+    return 1
+  else
+    pprint "Files extracted successfully, removing ${selected% *}..." "$fgBlue"
+    rm -f "${download_path}/${selected% *}"
+  fi
 fi
 
-# if tar return code is not 0, then download failed
-if [ $? -ne 0 ]; then
-  pprint "\nError: Extracting ${selected% *} failed." "$fgRed" "$txBold"
-  return 1
-else
-  pprint "Files extracted successfully, removing ${selected% *}..." "$fgBlue"
-  rm -f "${download_path}/${selected% *}"
-fi
-
-# list the extracted files
-pprint "\nExtracted files:" "$fgOrange"
+# list the files
+pprint -n "\nfiles in:" "$fgOrange"; pprint " ${download_path}" "$fgOrange" "$txBold"
 for file in "${download_path}"/*; do
   pprint " • $(basename "$file")"
 done


### PR DESCRIPTION
### `oh-my-zsh` fix:

* [`omz/functions/get_release`](diffhunk://#diff-398970f080c0f62c935eba7e36da5e26b2294b453a73ae4152f3e32d3530da14L238): Fixed the nesting of archive error handling inside the archive conditional and generalized the file listing. [[1]](diffhunk://#diff-398970f080c0f62c935eba7e36da5e26b2294b453a73ae4152f3e32d3530da14L238) [[2]](diffhunk://#diff-398970f080c0f62c935eba7e36da5e26b2294b453a73ae4152f3e32d3530da14R247-R250)