### PR TITLE
Feature/autocomplete

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.3.0
+  version: 2.4.0
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v2.4.0 (2024-12-27)
+
+### Feature
+
+- **omz**: manage zsh completions by removing dead symlinks and ensuring existing completions are symlinked
+- **omz**: add zsh autocompletion for decode_cert, get_release, and install_it functions
+
+### Fix
+
+- **omz**: remove non-existent --help option from usage message
+
 ## v2.3.0 (2024-12-26)
 
 ### Feature

--- a/omz/completions/_decode_cert
+++ b/omz/completions/_decode_cert
@@ -1,0 +1,15 @@
+#compdef decode_cert
+
+# Completion for the "decode_cert" command.
+function _decode_cert() {
+  # We use `_arguments` to define completion for various flags.
+  # For each flag, we give a short description in brackets [...],
+  # and specify how the argument is completed (e.g. _files, _urls, etc.).
+  _arguments -s -S \
+    '(-r --raw)'{-r,--raw}'[Output certificate information in unformatted json]' \
+    '(-j --json)'{-j,--json}'[Output certificate information in json]' \
+    '(-y --yaml)'{-y,--yaml}'[Output certificate information in yaml]' \
+    '(-f --full)'{-f,--full}'[Output full certificate details]' \
+    '(-s --short)'{-s,--short}'[Output short certificate details]' \
+    '*:file:_files'
+}

--- a/omz/completions/_get_release
+++ b/omz/completions/_get_release
@@ -1,0 +1,15 @@
+#compdef get_release
+
+# Completion for the "get_release" command.
+function _get_release() {
+  # We use `_arguments` to define completion for various flags.
+  # For each flag, we give a short description in brackets [...],
+  # and specify how the argument is completed (e.g. _files, _urls, etc.).
+  _arguments -s -S \
+    '(-o --owner)'{-o,--owner}'[GitHub owner name]:owner' \
+    '(-r --repo)'{-r,--repo}'[GitHub repo name]:repo' \
+    '(-u --url)'{-u,--url}'[GitHub repo URL]:repo url:_urls' \
+    '(-d --download)'{-d,--download}'[Download the asset and exit]' \
+    '(-l --list)'{-l,--list}'[List the last 30 releases]' \
+    '(-v --version)'{-v,--version}'[Version to download]'
+}

--- a/omz/completions/_install_it
+++ b/omz/completions/_install_it
@@ -1,0 +1,11 @@
+#compdef install_it
+
+# Completion for the "install_it" command.
+function _install_it() {
+  # We use `_arguments` to define completion for various flags.
+  # For each flag, we give a short description in brackets [...],
+  # and specify how the argument is completed (e.g. _files, _urls, etc.).
+  _arguments -s -S \
+    '1:source_file:_files' \
+    '2:target_file:_files'
+}

--- a/omz/configure.sh
+++ b/omz/configure.sh
@@ -37,3 +37,13 @@ ln -sf "${DOTFILES_LOCATION}/omz/functions.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/
 ln -sf "${DOTFILES_LOCATION}/omz/variables.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/variables.zsh"
 ln -sf "${DOTFILES_LOCATION}/omz/zshrc" "${HOME}/.zshrc"
 ln -sf "${DOTFILES_LOCATION}/omz/p10k.zsh" "${HOME}/.p10k.zsh"
+
+# remove any dead symlinks from the completions directory
+find "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions" -type l ! -exec test -e {} \; -delete
+
+# ensure the custom completion directory exists
+mkdir "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions"
+# loop over all completions and symlink them
+for completion in "${DOTFILES_LOCATION}/omz/completions"/*; do
+  ln -sf "${completion}" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions/$(basename ${completion})"
+done

--- a/omz/functions/decode_cert
+++ b/omz/functions/decode_cert
@@ -15,7 +15,6 @@ Options:
   -y, --yaml   Output certificate information in yaml(yq). *default
   -f, --full   Output full certificate details.
   -s, --short  Output short certificate details(issuer, subject, dates). *default
-  -h, --help   Show this message and exit.
 
 Example:
   decode cert in yaml format with short details:


### PR DESCRIPTION
### New Zsh Command Completions:
* Added completion for the `decode_cert` command, including various flags for output formats and details. (`omz/completions/_decode_cert`)
* Added completion for the `get_release` command, including flags for GitHub owner, repo, URL, and other options. (`omz/completions/_get_release`)
* Added completion for the `install_it` command, specifying source and target files. (`omz/completions/_install_it`)

### OMZ Configuration Script Enhancements:
* Updated `configure.sh` to remove dead symlinks from the completions directory, ensure the directory exists, and create symlinks for all completions. (`omz/configure.sh`)

### OMZ Minor Changes:
* Removed the help flag `-h, --help` from the `decode_cert` function options. (`omz/functions/decode_cert`)