### PR TITLE
remove set -e from omz configure.sh script

### DIFF
--- a/omz/configure.sh
+++ b/omz/configure.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env zsh
 
-set -e
-
 # powerlevel10k theme
 if [ -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k" ]; then
   echo "Updating powerlevel10k theme"


### PR DESCRIPTION
* [`omz/configure.sh`](diffhunk://#diff-48b44c789eda4a99e8d47330ea4712cf7031dc3be75246f54c070558330be758L3-L4): Removed the `set -e` command to prevent the script from exiting on non-zero status.