### PR TITLE
improve omz configure.sh logic for managing zsh completions

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.4.1
+  version: 2.4.2
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.4.2 (2024-12-27)
+
+### Refactor
+
+- **omz**: improve omz configure.sh logic for managing zsh completions
+
 ## v2.4.1 (2024-12-27)
 
 ### Fix

--- a/omz/configure.sh
+++ b/omz/configure.sh
@@ -36,11 +36,13 @@ ln -sf "${DOTFILES_LOCATION}/omz/variables.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/
 ln -sf "${DOTFILES_LOCATION}/omz/zshrc" "${HOME}/.zshrc"
 ln -sf "${DOTFILES_LOCATION}/omz/p10k.zsh" "${HOME}/.p10k.zsh"
 
-# remove any dead symlinks from the completions directory
-find "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions" -type l ! -exec test -e {} \; -delete
+# remove any dead symlinks from the custom completions directory or create it if it doesn't exist
+if [ -e "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions" ]; then
+  find "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions" -type l ! -exec test -e {} \; -delete
+else
+  mkdir "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions"
+fi
 
-# ensure the custom completion directory exists
-mkdir "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions"
 # loop over all completions and symlink them
 for completion in "${DOTFILES_LOCATION}/omz/completions"/*; do
   ln -sf "${completion}" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions/$(basename ${completion})"


### PR DESCRIPTION
* [`omz/configure.sh`](diffhunk://#diff-48b44c789eda4a99e8d47330ea4712cf7031dc3be75246f54c070558330be758L39-R45): Added a conditional check to remove dead symlinks from the custom completions directory if it exists, or create the directory if it does not exist.