### PR TITLE
realign key mappings and improve neovim markdown handling

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.5.0
+  version: 2.5.1
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v2.5.1 (2025-01-05)
+
+### Fix
+
+- **nvim**: add obsidian plugin
+- **nvim**: realign keymappings and add icons to which-key
+- **nvim**: add bullets plugin for markdown
+- **nvim**: add render markdown to auto complete
+- **nvim**: add keymap for next/prev git hunks
+- **nvim**: add keymap for TodoFzfLua
+- **nvim**: correct spelling vim options
+- **nvim**: stop using system clipboard for default register
+
 ## v2.5.0 (2025-01-02)
 
 ### Feature

--- a/neovim/lazy-nvim/lua/jake/core/keymaps.lua
+++ b/neovim/lazy-nvim/lua/jake/core/keymaps.lua
@@ -9,7 +9,7 @@ local keymap = vim.keymap -- for conciseness
 keymap.set("i", "jk", "<ESC>", { desc = "Exit insert mode with jk" })
 
 -- clear search highlights
-keymap.set("n", "<leader>nh", ":nohl<CR>", { desc = "Clear search highlights" })
+keymap.set("n", "<leader>ch", ":nohl<CR>", { desc = "Clear search highlights" })
 
 -- increment/decrement numbers
 keymap.set("n", "<leader>+", "<C-a>", { desc = "Increment number" }) -- increment
@@ -20,8 +20,8 @@ keymap.set("n", "<leader>sv", "<C-w>v", { desc = "Split window vertically" }) --
 keymap.set("n", "<leader>sh", "<C-w>s", { desc = "Split window horizontally" }) -- split window horizontally
 keymap.set("n", "<leader>se", "<C-w>=", { desc = "Make splits equal size" }) -- make split windows equal width & height
 keymap.set("n", "<leader>sx", "<cmd>close<CR>", { desc = "Close current split" }) -- close current split window
-keymap.set("n", "<C-W>,", ":vertical resize -10<CR>", { noremap = true })
-keymap.set("n", "<C-W>.", ":vertical resize +10<CR>", { noremap = true })
+keymap.set("n", "<C-W>,", "Decrease width -10<CR>", { noremap = true })
+keymap.set("n", "<C-W>.", "Increase width +10<CR>", { noremap = true })
 
 keymap.set("n", "<leader>to", "<cmd>tabnew<CR>", { desc = "Open new tab" }) -- open new tab
 keymap.set("n", "<leader>tx", "<cmd>tabclose<CR>", { desc = "Close current tab" }) -- close current tab
@@ -29,5 +29,7 @@ keymap.set("n", "<leader>tn", "<cmd>tabn<CR>", { desc = "Go to next tab" }) --  
 keymap.set("n", "<leader>tp", "<cmd>tabp<CR>", { desc = "Go to previous tab" }) --  go to previous tab
 keymap.set("n", "<leader>tf", "<cmd>tabnew %<CR>", { desc = "Open current buffer in new tab" }) --  move current buffer to new tab
 
-keymap.set("n", "<leader>se", ":setlocal spell spelllang=en_us<cr>", { desc = "spelling en", noremap = true })
-keymap.set("n", "<leader>sd", ":setlocal nospell<cr>", { desc = "spelling disable", noremap = true })
+keymap.set("n", "<leader>cse", ":setlocal spell spelllang=en_us<cr>", { desc = "spelling en", noremap = true })
+keymap.set("n", "<leader>csd", ":setlocal nospell<cr>", { desc = "spelling disable", noremap = true })
+
+keymap.set("n", "<leader>qq", ":qa<cr>", { desc = "Quit", noremap = true })

--- a/neovim/lazy-nvim/lua/jake/core/options.lua
+++ b/neovim/lazy-nvim/lua/jake/core/options.lua
@@ -33,9 +33,6 @@ opt.signcolumn = "yes" -- show sign column so that text doesn't shift
 -- backspace
 opt.backspace = "indent,eol,start" -- allow backspace on indent, end of line or insert mode start position
 
--- clipboard
-opt.clipboard:append("unnamedplus") -- use system clipboard as default register
-
 -- split windows
 opt.splitright = true -- split vertical window to the right
 opt.splitbelow = true -- split horizontal window to the bottom

--- a/neovim/lazy-nvim/lua/jake/core/options.lua
+++ b/neovim/lazy-nvim/lua/jake/core/options.lua
@@ -41,5 +41,5 @@ opt.splitbelow = true -- split horizontal window to the bottom
 opt.swapfile = false
 
 -- enable spell checker
-vim.opt.spelllang = "en_us"
-vim.opt.spell = true
+opt.spelllang = "en_us"
+opt.spell = true

--- a/neovim/lazy-nvim/lua/jake/lazy.lua
+++ b/neovim/lazy-nvim/lua/jake/lazy.lua
@@ -1,22 +1,22 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not vim.loop.fs_stat(lazypath) then
-	vim.fn.system({
-		"git",
-		"clone",
-		"--filter=blob:none",
-		"https://github.com/folke/lazy.nvim.git",
-		"--branch=stable", -- latest stable release
-		lazypath,
-	})
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable", -- latest stable release
+    lazypath,
+  })
 end
 vim.opt.rtp:prepend(lazypath)
 
 require("lazy").setup({ { import = "jake.plugins" }, { import = "jake.plugins.lsp" } }, {
-	checker = {
-		enabled = true,
-		notify = false,
-	},
-	change_detection = {
-		notify = false,
-	},
+  checker = {
+    enabled = true,
+    notify = false,
+  },
+  change_detection = {
+    notify = false,
+  },
 })

--- a/neovim/lazy-nvim/lua/jake/plugins/alpha.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/alpha.lua
@@ -1,109 +1,109 @@
 return {
-	-- https://github.com/goolord/alpha-nvim
-	"goolord/alpha-nvim",
-	-- NOTE: no releases, no tags
-	event = "VimEnter",
-	dependencies = {
-		"nvim-tree/nvim-web-devicons",
-		"nvim-lua/plenary.nvim",
-	},
+  -- https://github.com/goolord/alpha-nvim
+  "goolord/alpha-nvim",
+  -- NOTE: no releases, no tags
+  event = "VimEnter",
+  dependencies = {
+    "nvim-tree/nvim-web-devicons",
+    "nvim-lua/plenary.nvim",
+  },
 
-	config = function()
-		local dashboard = require("alpha.themes.dashboard")
+  config = function()
+    local dashboard = require("alpha.themes.dashboard")
 
-		-- Set menu
-		dashboard.section.buttons.val = {
-			dashboard.button("␣ ff", "󰱼  > Find file", "<cmd>FzfLua files<CR>"),
-			dashboard.button("e", "  > New file", "<cmd>ene<CR>"),
-			dashboard.button("␣ fr", "  > Recent files", "<cmd>FzfLua oldfiles<CR>"),
-			dashboard.button("␣ fs", "  > Find text", "<cmd>FzfLua live_grep<CR>"),
-			dashboard.button("␣ ee", "  > file explorer", "<cmd>NvimTreeToggle<CR>"),
-			dashboard.button("␣ wr", "󰁯  > Restore Session", "<cmd>SessionRestore<CR>"),
-			dashboard.button("l", "󰁯  > Lazy", "<cmd>Lazy<CR>"),
-			dashboard.button("q", "  > Quit NVIM", "<cmd>qa<CR>"),
-		}
+    -- Set menu
+    dashboard.section.buttons.val = {
+      dashboard.button("␣ ff", "󰱼  > Find file", "<cmd>FzfLua files<CR>"),
+      dashboard.button("e", "  > New file", "<cmd>ene<CR>"),
+      dashboard.button("␣ fr", "  > Recent files", "<cmd>FzfLua oldfiles<CR>"),
+      dashboard.button("␣ fs", "  > Find text", "<cmd>FzfLua live_grep<CR>"),
+      dashboard.button("␣ ee", "  > file explorer", "<cmd>NvimTreeToggle<CR>"),
+      dashboard.button("␣ wr", "󰁯  > Restore Session", "<cmd>SessionRestore<CR>"),
+      dashboard.button("l", "󰁯  > Lazy", "<cmd>Lazy<CR>"),
+      dashboard.button("q", "  > Quit NVIM", "<cmd>qa<CR>"),
+    }
 
-		-- helper function for utf8 chars
-		local function getCharLen(s, pos)
-			local byte = string.byte(s, pos)
-			if not byte then
-				return nil
-			end
-			return (byte < 0x80 and 1) or (byte < 0xE0 and 2) or (byte < 0xF0 and 3) or (byte < 0xF8 and 4) or 1
-		end
+    -- helper function for utf8 chars
+    local function getCharLen(s, pos)
+      local byte = string.byte(s, pos)
+      if not byte then
+        return nil
+      end
+      return (byte < 0x80 and 1) or (byte < 0xE0 and 2) or (byte < 0xF0 and 3) or (byte < 0xF8 and 4) or 1
+    end
 
-		local function applyColors(logo, colors, logoColors)
-			dashboard.section.header.val = logo
+    local function applyColors(logo, colors, logoColors)
+      dashboard.section.header.val = logo
 
-			for key, color in pairs(colors) do
-				local name = "Alpha" .. key
-				vim.api.nvim_set_hl(0, name, color)
-				colors[key] = name
-			end
+      for key, color in pairs(colors) do
+        local name = "Alpha" .. key
+        vim.api.nvim_set_hl(0, name, color)
+        colors[key] = name
+      end
 
-			dashboard.section.header.opts.hl = {}
-			for i, line in ipairs(logoColors) do
-				local highlights = {}
-				local pos = 0
+      dashboard.section.header.opts.hl = {}
+      for i, line in ipairs(logoColors) do
+        local highlights = {}
+        local pos = 0
 
-				for j = 1, #line do
-					local opos = pos
-					pos = pos + getCharLen(logo[i], opos + 1)
+        for j = 1, #line do
+          local opos = pos
+          pos = pos + getCharLen(logo[i], opos + 1)
 
-					local color_name = colors[line:sub(j, j)]
-					if color_name then
-						table.insert(highlights, { color_name, opos, pos })
-					end
-				end
+          local color_name = colors[line:sub(j, j)]
+          if color_name then
+            table.insert(highlights, { color_name, opos, pos })
+          end
+        end
 
-				table.insert(dashboard.section.header.opts.hl, highlights)
-			end
-			return dashboard.opts
-		end
+        table.insert(dashboard.section.header.opts.hl, highlights)
+      end
+      return dashboard.opts
+    end
 
-		require("alpha").setup(applyColors({
-			[[  ███       ███  ]],
-			[[  ████      ████ ]],
-			[[  ████     █████ ]],
-			[[ █ ████    █████ ]],
-			[[ ██ ████   █████ ]],
-			[[ ███ ████  █████ ]],
-			[[ ████ ████ ████ ]],
-			[[ █████  ████████ ]],
-			[[ █████   ███████ ]],
-			[[ █████    ██████ ]],
-			[[ █████     █████ ]],
-			[[ ████      ████ ]],
-			[[  ███       ███  ]],
-			[[                    ]],
-			[[  N  E  O  V  I  M  ]],
-		}, {
-			["b"] = { fg = "#3399ff", ctermfg = 33 },
-			["a"] = { fg = "#53C670", ctermfg = 35 },
-			["g"] = { fg = "#39ac56", ctermfg = 29 },
-			["h"] = { fg = "#33994d", ctermfg = 23 },
-			["i"] = { fg = "#33994d", bg = "#39ac56", ctermfg = 23, ctermbg = 29 },
-			["j"] = { fg = "#53C670", bg = "#33994d", ctermfg = 35, ctermbg = 23 },
-			["k"] = { fg = "#30A572", ctermfg = 36 },
-		}, {
-			[[  kkkka       gggg  ]],
-			[[  kkkkaa      ggggg ]],
-			[[ b kkkaaa     ggggg ]],
-			[[ bb kkaaaa    ggggg ]],
-			[[ bbb kaaaaa   ggggg ]],
-			[[ bbbb aaaaaa  ggggg ]],
-			[[ bbbbb aaaaaa igggg ]],
-			[[ bbbbb  aaaaaahiggg ]],
-			[[ bbbbb   aaaaajhigg ]],
-			[[ bbbbb    aaaaajhig ]],
-			[[ bbbbb     aaaaajhi ]],
-			[[ bbbbb      aaaaajh ]],
-			[[  bbbb       aaaaa  ]],
-			[[                    ]],
-			[[  a  a  a  b  b  b  ]],
-		}))
+    require("alpha").setup(applyColors({
+      [[  ███       ███  ]],
+      [[  ████      ████ ]],
+      [[  ████     █████ ]],
+      [[ █ ████    █████ ]],
+      [[ ██ ████   █████ ]],
+      [[ ███ ████  █████ ]],
+      [[ ████ ████ ████ ]],
+      [[ █████  ████████ ]],
+      [[ █████   ███████ ]],
+      [[ █████    ██████ ]],
+      [[ █████     █████ ]],
+      [[ ████      ████ ]],
+      [[  ███       ███  ]],
+      [[                    ]],
+      [[  N  E  O  V  I  M  ]],
+    }, {
+      ["b"] = { fg = "#3399ff", ctermfg = 33 },
+      ["a"] = { fg = "#53C670", ctermfg = 35 },
+      ["g"] = { fg = "#39ac56", ctermfg = 29 },
+      ["h"] = { fg = "#33994d", ctermfg = 23 },
+      ["i"] = { fg = "#33994d", bg = "#39ac56", ctermfg = 23, ctermbg = 29 },
+      ["j"] = { fg = "#53C670", bg = "#33994d", ctermfg = 35, ctermbg = 23 },
+      ["k"] = { fg = "#30A572", ctermfg = 36 },
+    }, {
+      [[  kkkka       gggg  ]],
+      [[  kkkkaa      ggggg ]],
+      [[ b kkkaaa     ggggg ]],
+      [[ bb kkaaaa    ggggg ]],
+      [[ bbb kaaaaa   ggggg ]],
+      [[ bbbb aaaaaa  ggggg ]],
+      [[ bbbbb aaaaaa igggg ]],
+      [[ bbbbb  aaaaaahiggg ]],
+      [[ bbbbb   aaaaajhigg ]],
+      [[ bbbbb    aaaaajhig ]],
+      [[ bbbbb     aaaaajhi ]],
+      [[ bbbbb      aaaaajh ]],
+      [[  bbbb       aaaaa  ]],
+      [[                    ]],
+      [[  a  a  a  b  b  b  ]],
+    }))
 
-		-- Disable folding on alpha buffer
-		vim.cmd([[autocmd FileType alpha setlocal nofoldenable]])
-	end,
+    -- Disable folding on alpha buffer
+    vim.cmd([[autocmd FileType alpha setlocal nofoldenable]])
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/alpha.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/alpha.lua
@@ -18,7 +18,7 @@ return {
       dashboard.button("␣ fr", "  > Recent files", "<cmd>FzfLua oldfiles<CR>"),
       dashboard.button("␣ fs", "  > Find text", "<cmd>FzfLua live_grep<CR>"),
       dashboard.button("␣ ee", "  > file explorer", "<cmd>NvimTreeToggle<CR>"),
-      dashboard.button("␣ wr", "󰁯  > Restore Session", "<cmd>SessionRestore<CR>"),
+      dashboard.button("␣ qr", "󰁯  > Restore Session", "<cmd>SessionRestore<CR>"),
       dashboard.button("l", "󰁯  > Lazy", "<cmd>Lazy<CR>"),
       dashboard.button("q", "  > Quit NVIM", "<cmd>qa<CR>"),
     }

--- a/neovim/lazy-nvim/lua/jake/plugins/auto-session.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/auto-session.lua
@@ -13,7 +13,7 @@ return {
     vim.o.sessionoptions = "blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"
 
     local keymap = vim.keymap
-    keymap.set("n", "<leader>wr", "<cmd>SessionRestore<CR>", { desc = "Restore session for cwd" }) -- restore last workspace session for current directory
-    keymap.set("n", "<leader>ws", "<cmd>SessionSave<CR>", { desc = "Save session for auto session root dir" }) -- save workspace session for current working directory
+    keymap.set("n", "<leader>qr", "<cmd>SessionRestore<CR>", { desc = "Restore session for cwd" }) -- restore last workspace session for current directory
+    keymap.set("n", "<leader>qs", "<cmd>SessionSave<CR>", { desc = "Save session for auto session root dir" }) -- save workspace session for current working directory
   end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/auto-session.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/auto-session.lua
@@ -1,19 +1,19 @@
 return {
-	-- https://github.com/rmagatti/auto-session
-	"rmagatti/auto-session",
-	-- NOTE: no releases, tags only
-	config = function()
-		local auto_session = require("auto-session")
+  -- https://github.com/rmagatti/auto-session
+  "rmagatti/auto-session",
+  -- NOTE: no releases, tags only
+  config = function()
+    local auto_session = require("auto-session")
 
-		auto_session.setup({
-			auto_restore = false,
-			suppressed_dirs = { "~/", "~/Dev/", "~/Downloads", "~/Documents", "~/Desktop/" },
-		})
+    auto_session.setup({
+      auto_restore = false,
+      suppressed_dirs = { "~/", "~/Dev/", "~/Downloads", "~/Documents", "~/Desktop/" },
+    })
 
-		vim.o.sessionoptions = "blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"
+    vim.o.sessionoptions = "blank,buffers,curdir,folds,help,tabpages,winsize,winpos,terminal,localoptions"
 
-		local keymap = vim.keymap
-		keymap.set("n", "<leader>wr", "<cmd>SessionRestore<CR>", { desc = "Restore session for cwd" }) -- restore last workspace session for current directory
-		keymap.set("n", "<leader>ws", "<cmd>SessionSave<CR>", { desc = "Save session for auto session root dir" }) -- save workspace session for current working directory
-	end,
+    local keymap = vim.keymap
+    keymap.set("n", "<leader>wr", "<cmd>SessionRestore<CR>", { desc = "Restore session for cwd" }) -- restore last workspace session for current directory
+    keymap.set("n", "<leader>ws", "<cmd>SessionSave<CR>", { desc = "Save session for auto session root dir" }) -- save workspace session for current working directory
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/autopairs.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/autopairs.lua
@@ -1,32 +1,32 @@
 return {
-	-- https://github.com/windwp/nvim-autopairs
-	"windwp/nvim-autopairs",
-	-- NOTE: no releases, no tags
-	event = { "InsertEnter" },
-	dependencies = {
-		"hrsh7th/nvim-cmp",
-	},
-	config = function()
-		-- import nvim-autopairs
-		local autopairs = require("nvim-autopairs")
+  -- https://github.com/windwp/nvim-autopairs
+  "windwp/nvim-autopairs",
+  -- NOTE: no releases, no tags
+  event = { "InsertEnter" },
+  dependencies = {
+    "hrsh7th/nvim-cmp",
+  },
+  config = function()
+    -- import nvim-autopairs
+    local autopairs = require("nvim-autopairs")
 
-		-- configure autopairs
-		autopairs.setup({
-			check_ts = true, -- enable treesitter
-			ts_config = {
-				lua = { "string" }, -- don't add pairs in lua string treesitter nodes
-				javascript = { "template_string" }, -- don't add pairs in javscript template_string treesitter nodes
-				java = false, -- don't check treesitter on java
-			},
-		})
+    -- configure autopairs
+    autopairs.setup({
+      check_ts = true, -- enable treesitter
+      ts_config = {
+        lua = { "string" }, -- don't add pairs in lua string treesitter nodes
+        javascript = { "template_string" }, -- don't add pairs in javscript template_string treesitter nodes
+        java = false, -- don't check treesitter on java
+      },
+    })
 
-		-- import nvim-autopairs completion functionality
-		local cmp_autopairs = require("nvim-autopairs.completion.cmp")
+    -- import nvim-autopairs completion functionality
+    local cmp_autopairs = require("nvim-autopairs.completion.cmp")
 
-		-- import nvim-cmp plugin (completions plugin)
-		local cmp = require("cmp")
+    -- import nvim-cmp plugin (completions plugin)
+    local cmp = require("cmp")
 
-		-- make autopairs and completion work together
-		cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())
-	end,
+    -- make autopairs and completion work together
+    cmp.event:on("confirm_done", cmp_autopairs.on_confirm_done())
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/bufferline.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/bufferline.lua
@@ -1,12 +1,12 @@
 return {
-	-- https://github.com/akinsho/bufferline.nvim
-	"akinsho/bufferline.nvim",
-	version = "4.*",
-	dependencies = { "nvim-tree/nvim-web-devicons" },
-	opts = {
-		options = {
-			mode = "tabs",
-			separator_style = "slant",
-		},
-	},
+  -- https://github.com/akinsho/bufferline.nvim
+  "akinsho/bufferline.nvim",
+  version = "4.*",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  opts = {
+    options = {
+      mode = "tabs",
+      separator_style = "slant",
+    },
+  },
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/bullets.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/bullets.lua
@@ -1,0 +1,26 @@
+-- Filename: ~/github/dotfiles-latest/neovim/neobean/lua/plugins/bullets.lua
+-- ~/github/dotfiles-latest/neovim/neobean/lua/plugins/bullets.lua
+--
+-- This plugin automatically adds bulletpoints on the next line respecting
+-- indentation
+-- In markdown or a text file start a bulleted list using - or *. Press return
+-- to go to the next line, a new list item will be created.
+--
+-- When in insert mode, you can increase indentation with ctrl+t and decrease it
+-- with ctrl+d
+--
+-- By default its enabled on filetypes 'markdown', 'text', 'gitcommit', 'scratch'
+-- https://github.com/bullets-vim/bullets.vim
+
+return {
+  "bullets-vim/bullets.vim",
+  config = function()
+    -- Disable deleting the last empty bullet when pressing <cr> or 'o'
+    -- default = 1
+    vim.g.bullets_delete_last_bullet_if_empty = 1
+
+    -- (Optional) Add other configurations here
+    -- For example, enabling/disabling mappings
+    -- vim.g.bullets_set_mappings = 1
+  end,
+}

--- a/neovim/lazy-nvim/lua/jake/plugins/colorscheme.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/colorscheme.lua
@@ -1,40 +1,40 @@
 return {
-	-- https://github.com/folke/tokyonight.nvim
-	"folke/tokyonight.nvim",
-	version = "4.*",
-	priority = 1000, -- make sure to load this before all the other start plugins
-	config = function()
-		local bg = "#011628"
-		local bg_dark = "#011423"
-		local bg_highlight = "#143652"
-		local bg_search = "#0A64AC"
-		local bg_visual = "#275378"
-		local fg = "#CBE0F0"
-		local fg_dark = "#B4D0E9"
-		local fg_gutter = "#627E97"
-		local border = "#547998"
+  -- https://github.com/folke/tokyonight.nvim
+  "folke/tokyonight.nvim",
+  version = "4.*",
+  priority = 1000, -- make sure to load this before all the other start plugins
+  config = function()
+    local bg = "#011628"
+    local bg_dark = "#011423"
+    local bg_highlight = "#143652"
+    local bg_search = "#0A64AC"
+    local bg_visual = "#275378"
+    local fg = "#CBE0F0"
+    local fg_dark = "#B4D0E9"
+    local fg_gutter = "#627E97"
+    local border = "#547998"
 
-		require("tokyonight").setup({
-			style = "night",
-			on_colors = function(colors)
-				colors.bg = bg
-				colors.bg_dark = bg_dark
-				colors.bg_float = bg_dark
-				colors.bg_highlight = bg_highlight
-				colors.bg_popup = bg_dark
-				colors.bg_search = bg_search
-				colors.bg_sidebar = bg_dark
-				colors.bg_statusline = bg_dark
-				colors.bg_visual = bg_visual
-				colors.border = border
-				colors.fg = fg
-				colors.fg_dark = fg_dark
-				colors.fg_float = fg
-				colors.fg_gutter = fg_gutter
-				colors.fg_sidebar = fg_dark
-			end,
-		})
-		-- load the colorscheme here
-		vim.cmd([[colorscheme tokyonight]])
-	end,
+    require("tokyonight").setup({
+      style = "night",
+      on_colors = function(colors)
+        colors.bg = bg
+        colors.bg_dark = bg_dark
+        colors.bg_float = bg_dark
+        colors.bg_highlight = bg_highlight
+        colors.bg_popup = bg_dark
+        colors.bg_search = bg_search
+        colors.bg_sidebar = bg_dark
+        colors.bg_statusline = bg_dark
+        colors.bg_visual = bg_visual
+        colors.border = border
+        colors.fg = fg
+        colors.fg_dark = fg_dark
+        colors.fg_float = fg
+        colors.fg_gutter = fg_gutter
+        colors.fg_sidebar = fg_dark
+      end,
+    })
+    -- load the colorscheme here
+    vim.cmd([[colorscheme tokyonight]])
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/comment.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/comment.lua
@@ -1,24 +1,24 @@
 return {
-	-- https://github.com/numToStr/Comment.nvim
-	"numToStr/Comment.nvim",
-	version = "0.*",
-	event = { "BufReadPre", "BufNewFile" },
-	dependencies = {
-		"JoosepAlviste/nvim-ts-context-commentstring",
-	},
-	config = function()
-		-- import comment plugin safely
-		local comment = require("Comment")
+  -- https://github.com/numToStr/Comment.nvim
+  "numToStr/Comment.nvim",
+  version = "0.*",
+  event = { "BufReadPre", "BufNewFile" },
+  dependencies = {
+    "JoosepAlviste/nvim-ts-context-commentstring",
+  },
+  config = function()
+    -- import comment plugin safely
+    local comment = require("Comment")
 
-		local ts_context_commentstring = require("ts_context_commentstring.integrations.comment_nvim")
+    local ts_context_commentstring = require("ts_context_commentstring.integrations.comment_nvim")
 
-		-- enable comment
-		comment.setup({
-			-- for commenting tsx, jsx, svelte, html files
-			pre_hook = ts_context_commentstring.create_pre_hook(),
-			vim.keymap.set("n", "<C-_>", function()
-				require("Comment.api").toggle.linewise.current()
-			end, { noremap = true, silent = true }),
-		})
-	end,
+    -- enable comment
+    comment.setup({
+      -- for commenting tsx, jsx, svelte, html files
+      pre_hook = ts_context_commentstring.create_pre_hook(),
+      vim.keymap.set("n", "<C-_>", function()
+        require("Comment.api").toggle.linewise.current()
+      end, { noremap = true, silent = true }),
+    })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/dressing.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/dressing.lua
@@ -1,6 +1,6 @@
 return {
-	-- https://github.com/stevearc/dressing.nvim
-	"stevearc/dressing.nvim",
-	-- NOTE: no releases, tags only
-	event = "VeryLazy",
+  -- https://github.com/stevearc/dressing.nvim
+  "stevearc/dressing.nvim",
+  -- NOTE: no releases, tags only
+  event = "VeryLazy",
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/formatter.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/formatter.lua
@@ -30,7 +30,7 @@ return {
       },
     })
 
-    vim.keymap.set({ "n", "v" }, "<leader>mp", function()
+    vim.keymap.set({ "n", "v" }, "<leader>cf", function()
       conform.format({
         lsp_fallback = true,
         async = false,

--- a/neovim/lazy-nvim/lua/jake/plugins/formatter.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/formatter.lua
@@ -1,41 +1,41 @@
 return {
-	-- https://github.com/stevearc/conform.nvim
-	"stevearc/conform.nvim",
-	version = "8.*",
-	event = { "BufReadPre", "BufNewFile" },
-	config = function()
-		local conform = require("conform")
+  -- https://github.com/stevearc/conform.nvim
+  "stevearc/conform.nvim",
+  version = "8.*",
+  event = { "BufReadPre", "BufNewFile" },
+  config = function()
+    local conform = require("conform")
 
-		conform.setup({
-			formatters_by_ft = {
-				javascript = { "prettier" },
-				typescript = { "prettier" },
-				javascriptreact = { "prettier" },
-				typescriptreact = { "prettier" },
-				svelte = { "prettier" },
-				css = { "prettier" },
-				html = { "prettier" },
-				json = { "prettier" },
-				yaml = { "prettier" },
-				markdown = { "prettier" },
-				graphql = { "prettier" },
-				liquid = { "prettier" },
-				lua = { "stylua" },
-				python = { "isort", "black" },
-			},
-			format_on_save = {
-				lsp_fallback = true,
-				async = false,
-				timeout_ms = 1000,
-			},
-		})
+    conform.setup({
+      formatters_by_ft = {
+        javascript = { "prettier" },
+        typescript = { "prettier" },
+        javascriptreact = { "prettier" },
+        typescriptreact = { "prettier" },
+        svelte = { "prettier" },
+        css = { "prettier" },
+        html = { "prettier" },
+        json = { "prettier" },
+        yaml = { "prettier" },
+        markdown = { "prettier" },
+        graphql = { "prettier" },
+        liquid = { "prettier" },
+        lua = { "stylua" },
+        python = { "isort", "black" },
+      },
+      format_on_save = {
+        lsp_fallback = true,
+        async = false,
+        timeout_ms = 1000,
+      },
+    })
 
-		vim.keymap.set({ "n", "v" }, "<leader>mp", function()
-			conform.format({
-				lsp_fallback = true,
-				async = false,
-				timeout_ms = 1000,
-			})
-		end, { desc = "Format file or range (in visual mode)" })
-	end,
+    vim.keymap.set({ "n", "v" }, "<leader>mp", function()
+      conform.format({
+        lsp_fallback = true,
+        async = false,
+        timeout_ms = 1000,
+      })
+    end, { desc = "Format file or range (in visual mode)" })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/fzf.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/fzf.lua
@@ -50,6 +50,7 @@ return {
     keymap.set("n", "<leader>fq", "<cmd>FzfLua quickfix<cr>", { desc = "Fuzzy find quickfix list" })
     keymap.set("n", "<leader>fr", "<cmd>FzfLua oldfiles<cr>", { desc = "Fuzzy find recent files" })
     keymap.set("n", "<leader>fs", "<cmd>FzfLua live_grep<cr>", { desc = "Find string in cwd" })
+    keymap.set("n", "<leader>ft", "<cmd>TodoFzfLua<cr>", { desc = "Find Todo in cwd" })
 
     -- git keymaps
     keymap.set("n", "<leader>gb", "<cmd>FzfLua git_branches<cr>", { desc = "Fuzzy git branches" })

--- a/neovim/lazy-nvim/lua/jake/plugins/fzf.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/fzf.lua
@@ -1,63 +1,63 @@
 return {
-	-- https://github.com/ibhagwan/fzf-lua
-	"ibhagwan/fzf-lua",
-	-- NOTE: no releases, no tags
-	-- optional for icon support
-	dependencies = {
-		"nvim-tree/nvim-web-devicons",
-		"echasnovski/mini.icons",
-	},
-	-- or if using mini.icons/mini.nvim
-	opts = {},
+  -- https://github.com/ibhagwan/fzf-lua
+  "ibhagwan/fzf-lua",
+  -- NOTE: no releases, no tags
+  -- optional for icon support
+  dependencies = {
+    "nvim-tree/nvim-web-devicons",
+    "echasnovski/mini.icons",
+  },
+  -- or if using mini.icons/mini.nvim
+  opts = {},
 
-	config = function()
-		local fzf_lua = require("fzf-lua")
+  config = function()
+    local fzf_lua = require("fzf-lua")
 
-		fzf_lua.setup({
-			winopts = {
-				height = 0.85,
-				width = 0.90,
-				preview = {
-					border = "noborder",
-					hidden = "nohidden",
-				},
-			},
-			lsp = { async_or_timeout = 3000 },
-			files = {
-				input_prompt = "Files❯ ",
-				prompt = "Files❯ ",
-			},
-			grep = {
-				input_prompt = "Rg❯ ",
-				prompt = "Rg❯ ",
-			},
-			previewers = {
-				bat = {
-					theme = "tokyonight_night",
-				},
-			},
-		})
+    fzf_lua.setup({
+      winopts = {
+        height = 0.85,
+        width = 0.90,
+        preview = {
+          border = "noborder",
+          hidden = "nohidden",
+        },
+      },
+      lsp = { async_or_timeout = 3000 },
+      files = {
+        input_prompt = "Files❯ ",
+        prompt = "Files❯ ",
+      },
+      grep = {
+        input_prompt = "Rg❯ ",
+        prompt = "Rg❯ ",
+      },
+      previewers = {
+        bat = {
+          theme = "tokyonight_night",
+        },
+      },
+    })
 
-		local keymap = vim.keymap -- for conciseness
+    local keymap = vim.keymap -- for conciseness
 
-		keymap.set("n", "<leader>fb", "<cmd>FzfLua buffers<cr>", { desc = "Fuzzy find buffers" })
-		keymap.set("n", "<leader>fc", "<cmd>FzfLua grep_cWORD<cr>", { desc = "Find string under cursor in cwd" })
-		keymap.set("n", "<leader>fe", "<cmd>FzfLua resume<cr>", { desc = "Fuzzy find resume" })
-		keymap.set("n", "<leader>ff", "<cmd>FzfLua files<cr>", { desc = "Fuzzy find files in cwd" })
-		keymap.set("n", "<C-p>", "<cmd>FzfLua files<cr>", { desc = "Fuzzy find files in cwd" })
-		keymap.set("n", "<leader>fg", "<cmd>FzfLua registers<cr>", { desc = "Fuzzy find registers" })
-		keymap.set("n", "<leader>fm", "<cmd>FzfLua marks<cr>", { desc = "Fuzzy find marks" })
-		keymap.set("n", "<leader>fq", "<cmd>FzfLua quickfix<cr>", { desc = "Fuzzy find quickfix list" })
-		keymap.set("n", "<leader>fr", "<cmd>FzfLua oldfiles<cr>", { desc = "Fuzzy find recent files" })
-		keymap.set("n", "<leader>fs", "<cmd>FzfLua live_grep<cr>", { desc = "Find string in cwd" })
+    keymap.set("n", "<leader>fb", "<cmd>FzfLua buffers<cr>", { desc = "Fuzzy find buffers" })
+    keymap.set("n", "<leader>fc", "<cmd>FzfLua grep_cWORD<cr>", { desc = "Find string under cursor in cwd" })
+    keymap.set("n", "<leader>fe", "<cmd>FzfLua resume<cr>", { desc = "Fuzzy find resume" })
+    keymap.set("n", "<leader>ff", "<cmd>FzfLua files<cr>", { desc = "Fuzzy find files in cwd" })
+    keymap.set("n", "<C-p>", "<cmd>FzfLua files<cr>", { desc = "Fuzzy find files in cwd" })
+    keymap.set("n", "<leader>fg", "<cmd>FzfLua registers<cr>", { desc = "Fuzzy find registers" })
+    keymap.set("n", "<leader>fm", "<cmd>FzfLua marks<cr>", { desc = "Fuzzy find marks" })
+    keymap.set("n", "<leader>fq", "<cmd>FzfLua quickfix<cr>", { desc = "Fuzzy find quickfix list" })
+    keymap.set("n", "<leader>fr", "<cmd>FzfLua oldfiles<cr>", { desc = "Fuzzy find recent files" })
+    keymap.set("n", "<leader>fs", "<cmd>FzfLua live_grep<cr>", { desc = "Find string in cwd" })
 
-		-- git keymaps
-		keymap.set("n", "<leader>gb", "<cmd>FzfLua git_branches<cr>", { desc = "Fuzzy git branches" })
-		keymap.set("n", "<leader>gc", "<cmd>FzfLua git_commits<cr>", { desc = "Fuzzy git commit log (project)" })
-		keymap.set("n", "<leader>gf", "<cmd>FzfLua git_files<cr>", { desc = "Fuzzy git ls-files" })
-		keymap.set("n", "<leader>gh", "<cmd>FzfLua git_stash<cr>", { desc = "Fuzzy git stash" })
-		keymap.set("n", "<leader>gs", "<cmd>FzfLua git_status<cr>", { desc = "Fuzzy git status" })
-		keymap.set("n", "<leader>gt", "<cmd>FzfLua git_tags<cr>", { desc = "Fuzzy git tags" })
-		keymap.set("n", "<leader>gw", "<cmd>FzfLua git_blame<cr>", { desc = "Fuzzy git blame" })
-	end,
+    -- git keymaps
+    keymap.set("n", "<leader>gb", "<cmd>FzfLua git_branches<cr>", { desc = "Fuzzy git branches" })
+    keymap.set("n", "<leader>gc", "<cmd>FzfLua git_commits<cr>", { desc = "Fuzzy git commit log (project)" })
+    keymap.set("n", "<leader>gf", "<cmd>FzfLua git_files<cr>", { desc = "Fuzzy git ls-files" })
+    keymap.set("n", "<leader>gh", "<cmd>FzfLua git_stash<cr>", { desc = "Fuzzy git stash" })
+    keymap.set("n", "<leader>gs", "<cmd>FzfLua git_status<cr>", { desc = "Fuzzy git status" })
+    keymap.set("n", "<leader>gt", "<cmd>FzfLua git_tags<cr>", { desc = "Fuzzy git tags" })
+    keymap.set("n", "<leader>gw", "<cmd>FzfLua git_blame<cr>", { desc = "Fuzzy git blame" })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/gitsigns.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/gitsigns.lua
@@ -1,52 +1,52 @@
 return {
-	-- https://github.com/lewis6991/gitsigns.nvim
-	"lewis6991/gitsigns.nvim",
-	version = "0.*",
-	event = { "BufReadPre", "BufNewFile" },
-	opts = {
-		on_attach = function(bufnr)
-			local gs = package.loaded.gitsigns
-			-- local gs = require("gitsigns")
+  -- https://github.com/lewis6991/gitsigns.nvim
+  "lewis6991/gitsigns.nvim",
+  version = "0.*",
+  event = { "BufReadPre", "BufNewFile" },
+  opts = {
+    on_attach = function(bufnr)
+      local gs = package.loaded.gitsigns
+      -- local gs = require("gitsigns")
 
-			local function map(mode, l, r, desc)
-				vim.keymap.set(mode, l, r, { buffer = bufnr, desc = desc })
-			end
+      local function map(mode, l, r, desc)
+        vim.keymap.set(mode, l, r, { buffer = bufnr, desc = desc })
+      end
 
-			-- local keymap = vim.keymap -- for conciseness
+      -- local keymap = vim.keymap -- for conciseness
 
-			-- Navigation
-			-- map("n", "]h", gs.nav_hunk("next"), "Next Hunk")
-			-- map("n", "[h", gs.nav_hunk("prev"), "Prev Hunk")
+      -- Navigation
+      -- map("n", "]h", gs.nav_hunk("next"), "Next Hunk")
+      -- map("n", "[h", gs.nav_hunk("prev"), "Prev Hunk")
 
-			-- Actions
-			map("n", "<leader>hs", gs.stage_hunk, "Stage hunk")
-			map("n", "<leader>hr", gs.reset_hunk, "Reset hunk")
-			map("v", "<leader>hs", function()
-				gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
-			end, "Stage hunk")
-			map("v", "<leader>hr", function()
-				gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
-			end, "Reset hunk")
+      -- Actions
+      map("n", "<leader>hs", gs.stage_hunk, "Stage hunk")
+      map("n", "<leader>hr", gs.reset_hunk, "Reset hunk")
+      map("v", "<leader>hs", function()
+        gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
+      end, "Stage hunk")
+      map("v", "<leader>hr", function()
+        gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
+      end, "Reset hunk")
 
-			map("n", "<leader>hS", gs.stage_buffer, "Stage buffer")
-			map("n", "<leader>hR", gs.reset_buffer, "Reset buffer")
+      map("n", "<leader>hS", gs.stage_buffer, "Stage buffer")
+      map("n", "<leader>hR", gs.reset_buffer, "Reset buffer")
 
-			map("n", "<leader>hu", gs.undo_stage_hunk, "Undo stage hunk")
+      map("n", "<leader>hu", gs.undo_stage_hunk, "Undo stage hunk")
 
-			map("n", "<leader>hp", gs.preview_hunk, "Preview hunk")
+      map("n", "<leader>hp", gs.preview_hunk, "Preview hunk")
 
-			map("n", "<leader>hb", function()
-				gs.blame_line({ full = true })
-			end, "Blame line")
-			map("n", "<leader>hB", gs.toggle_current_line_blame, "Toggle line blame")
+      map("n", "<leader>hb", function()
+        gs.blame_line({ full = true })
+      end, "Blame line")
+      map("n", "<leader>hB", gs.toggle_current_line_blame, "Toggle line blame")
 
-			map("n", "<leader>hd", gs.diffthis, "Diff this")
-			map("n", "<leader>hD", function()
-				gs.diffthis("~")
-			end, "Diff this ~")
+      map("n", "<leader>hd", gs.diffthis, "Diff this")
+      map("n", "<leader>hD", function()
+        gs.diffthis("~")
+      end, "Diff this ~")
 
-			-- Text object
-			map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>", "Gitsigns select hunk")
-		end,
-	},
+      -- Text object
+      map({ "o", "x" }, "ih", ":<C-U>Gitsigns select_hunk<CR>", "Gitsigns select hunk")
+    end,
+  },
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/gitsigns.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/gitsigns.lua
@@ -15,8 +15,21 @@ return {
       -- local keymap = vim.keymap -- for conciseness
 
       -- Navigation
-      -- map("n", "]h", gs.nav_hunk("next"), "Next Hunk")
-      -- map("n", "[h", gs.nav_hunk("prev"), "Prev Hunk")
+      map("n", "]h", function()
+        if vim.wo.diff then
+          vim.cmd.normal({ "]h", bang = true })
+        else
+          gs.nav_hunk("next")
+        end
+      end, "next hunk")
+
+      map("n", "[h", function()
+        if vim.wo.diff then
+          vim.cmd.normal({ "[h", bang = true })
+        else
+          gs.nav_hunk("prev")
+        end
+      end, "previous hunk")
 
       -- Actions
       map("n", "<leader>hs", gs.stage_hunk, "Stage hunk")

--- a/neovim/lazy-nvim/lua/jake/plugins/indent-blankline.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/indent-blankline.lua
@@ -1,10 +1,10 @@
 return {
-	-- https://github.com/lukas-reineke/indent-blankline.nvim
-	"lukas-reineke/indent-blankline.nvim",
-	version = "3.*",
-	event = { "BufReadPre", "BufNewFile" },
-	main = "ibl",
-	opts = {
-		indent = { char = "┊" },
-	},
+  -- https://github.com/lukas-reineke/indent-blankline.nvim
+  "lukas-reineke/indent-blankline.nvim",
+  version = "3.*",
+  event = { "BufReadPre", "BufNewFile" },
+  main = "ibl",
+  opts = {
+    indent = { char = "┊" },
+  },
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/init.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/init.lua
@@ -1,6 +1,6 @@
 return {
-	-- https://github.com/nvim-lua/plenary.nvim
-	"nvim-lua/plenary.nvim", -- lua functions that many plugins use
-	-- https://github.com/christoomey/vim-tmux-navigator
-	"christoomey/vim-tmux-navigator", -- tmux & split window navigation
+  -- https://github.com/nvim-lua/plenary.nvim
+  "nvim-lua/plenary.nvim", -- lua functions that many plugins use
+  -- https://github.com/christoomey/vim-tmux-navigator
+  "christoomey/vim-tmux-navigator", -- tmux & split window navigation
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/lsp/lspconfig.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/lsp/lspconfig.lua
@@ -1,139 +1,139 @@
 return {
-	-- https://github.com/neovim/nvim-lspconfig
-	"neovim/nvim-lspconfig",
-	version = "1.*",
-	event = { "BufReadPre", "BufNewFile" },
-	dependencies = {
-		"hrsh7th/cmp-nvim-lsp",
-		{ "antosha417/nvim-lsp-file-operations", config = true },
-		{ "folke/neodev.nvim", opts = {} },
-	},
-	config = function()
-		-- import lspconfig plugin
-		local lspconfig = require("lspconfig")
+  -- https://github.com/neovim/nvim-lspconfig
+  "neovim/nvim-lspconfig",
+  version = "1.*",
+  event = { "BufReadPre", "BufNewFile" },
+  dependencies = {
+    "hrsh7th/cmp-nvim-lsp",
+    { "antosha417/nvim-lsp-file-operations", config = true },
+    { "folke/neodev.nvim", opts = {} },
+  },
+  config = function()
+    -- import lspconfig plugin
+    local lspconfig = require("lspconfig")
 
-		-- import mason_lspconfig plugin
-		local mason_lspconfig = require("mason-lspconfig")
+    -- import mason_lspconfig plugin
+    local mason_lspconfig = require("mason-lspconfig")
 
-		-- import cmp-nvim-lsp plugin
-		local cmp_nvim_lsp = require("cmp_nvim_lsp")
+    -- import cmp-nvim-lsp plugin
+    local cmp_nvim_lsp = require("cmp_nvim_lsp")
 
-		local keymap = vim.keymap -- for conciseness
+    local keymap = vim.keymap -- for conciseness
 
-		vim.api.nvim_create_autocmd("LspAttach", {
-			group = vim.api.nvim_create_augroup("UserLspConfig", {}),
-			callback = function(ev)
-				-- Buffer local mappings.
-				-- See `:help vim.lsp.*` for documentation on any of the below functions
-				local opts = { buffer = ev.buf, silent = true }
+    vim.api.nvim_create_autocmd("LspAttach", {
+      group = vim.api.nvim_create_augroup("UserLspConfig", {}),
+      callback = function(ev)
+        -- Buffer local mappings.
+        -- See `:help vim.lsp.*` for documentation on any of the below functions
+        local opts = { buffer = ev.buf, silent = true }
 
-				-- set keybinds
-				opts.desc = "Show LSP references"
-				keymap.set("n", "gR", "<cmd>FzfLua lsp_references<CR>", opts) -- show definition, references
+        -- set keybinds
+        opts.desc = "Show LSP references"
+        keymap.set("n", "gR", "<cmd>FzfLua lsp_references<CR>", opts) -- show definition, references
 
-				opts.desc = "Go to declaration"
-				keymap.set("n", "gD", vim.lsp.buf.declaration, opts) -- go to declaration
+        opts.desc = "Go to declaration"
+        keymap.set("n", "gD", vim.lsp.buf.declaration, opts) -- go to declaration
 
-				opts.desc = "Show LSP definitions"
-				keymap.set("n", "gd", "<cmd>FzfLua lsp_definitions<CR>", opts) -- show lsp definitions
+        opts.desc = "Show LSP definitions"
+        keymap.set("n", "gd", "<cmd>FzfLua lsp_definitions<CR>", opts) -- show lsp definitions
 
-				opts.desc = "Show LSP implementations"
-				keymap.set("n", "gi", "<cmd>FzfLua lsp_implementations<CR>", opts) -- show lsp implementations
+        opts.desc = "Show LSP implementations"
+        keymap.set("n", "gi", "<cmd>FzfLua lsp_implementations<CR>", opts) -- show lsp implementations
 
-				opts.desc = "Show LSP type definitions"
-				keymap.set("n", "gt", "<cmd>FzfLua lsp_type_definitions<CR>", opts) -- show lsp type definitions
+        opts.desc = "Show LSP type definitions"
+        keymap.set("n", "gt", "<cmd>FzfLua lsp_type_definitions<CR>", opts) -- show lsp type definitions
 
-				opts.desc = "See available code actions"
-				keymap.set({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, opts) -- see available code actions, in visual mode will apply to selection
+        opts.desc = "See available code actions"
+        keymap.set({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, opts) -- see available code actions, in visual mode will apply to selection
 
-				opts.desc = "Smart rename"
-				keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts) -- smart rename
+        opts.desc = "Smart rename"
+        keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts) -- smart rename
 
-				opts.desc = "Show buffer diagnostics"
-				keymap.set("n", "<leader>D", "<cmd>FzfLua diagnostics bufnr=0<CR>", opts) -- show  diagnostics for file
+        opts.desc = "Show buffer diagnostics"
+        keymap.set("n", "<leader>D", "<cmd>FzfLua diagnostics bufnr=0<CR>", opts) -- show  diagnostics for file
 
-				opts.desc = "Show line diagnostics"
-				keymap.set("n", "<leader>d", vim.diagnostic.open_float, opts) -- show diagnostics for line
+        opts.desc = "Show line diagnostics"
+        keymap.set("n", "<leader>d", vim.diagnostic.open_float, opts) -- show diagnostics for line
 
-				opts.desc = "Go to previous diagnostic"
-				keymap.set("n", "[d", vim.diagnostic.goto_prev, opts) -- jump to previous diagnostic in buffer
+        opts.desc = "Go to previous diagnostic"
+        keymap.set("n", "[d", vim.diagnostic.goto_prev, opts) -- jump to previous diagnostic in buffer
 
-				opts.desc = "Go to next diagnostic"
-				keymap.set("n", "]d", vim.diagnostic.goto_next, opts) -- jump to next diagnostic in buffer
+        opts.desc = "Go to next diagnostic"
+        keymap.set("n", "]d", vim.diagnostic.goto_next, opts) -- jump to next diagnostic in buffer
 
-				opts.desc = "Show documentation for what is under cursor"
-				keymap.set("n", "K", vim.lsp.buf.hover, opts) -- show documentation for what is under cursor
+        opts.desc = "Show documentation for what is under cursor"
+        keymap.set("n", "K", vim.lsp.buf.hover, opts) -- show documentation for what is under cursor
 
-				opts.desc = "Restart LSP"
-				keymap.set("n", "<leader>rs", ":LspRestart<CR>", opts) -- mapping to restart lsp if necessary
-			end,
-		})
+        opts.desc = "Restart LSP"
+        keymap.set("n", "<leader>rs", ":LspRestart<CR>", opts) -- mapping to restart lsp if necessary
+      end,
+    })
 
-		-- used to enable autocompletion (assign to every lsp server config)
-		local capabilities = cmp_nvim_lsp.default_capabilities()
+    -- used to enable autocompletion (assign to every lsp server config)
+    local capabilities = cmp_nvim_lsp.default_capabilities()
 
-		-- Change the Diagnostic symbols in the sign column (gutter)
-		-- (not in youtube nvim video)
-		local signs = { Error = " ", Warn = " ", Hint = "󰠠 ", Info = " " }
-		for type, icon in pairs(signs) do
-			local hl = "DiagnosticSign" .. type
-			vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
-		end
+    -- Change the Diagnostic symbols in the sign column (gutter)
+    -- (not in youtube nvim video)
+    local signs = { Error = " ", Warn = " ", Hint = "󰠠 ", Info = " " }
+    for type, icon in pairs(signs) do
+      local hl = "DiagnosticSign" .. type
+      vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
+    end
 
-		mason_lspconfig.setup_handlers({
-			-- default handler for installed servers
-			function(server_name)
-				lspconfig[server_name].setup({
-					capabilities = capabilities,
-				})
-			end,
-			["marksman"] = function()
-				lspconfig["marksman"].setup({
-					capabilities = capabilities,
-					cmd = { "marksman", "server" },
-					filetypes = { "markdown", "mdx" },
-				})
-			end,
-			["graphql"] = function()
-				-- configure graphql language server
-				lspconfig["graphql"].setup({
-					capabilities = capabilities,
-					filetypes = { "graphql", "gql", "svelte", "typescriptreact", "javascriptreact" },
-				})
-			end,
-			["emmet_ls"] = function()
-				-- configure emmet language server
-				lspconfig["emmet_ls"].setup({
-					capabilities = capabilities,
-					filetypes = {
-						"html",
-						"typescriptreact",
-						"javascriptreact",
-						"css",
-						"sass",
-						"scss",
-						"less",
-						"svelte",
-					},
-				})
-			end,
-			["lua_ls"] = function()
-				-- configure lua server (with special settings)
-				lspconfig["lua_ls"].setup({
-					capabilities = capabilities,
-					settings = {
-						Lua = {
-							-- make the language server recognize "vim" global
-							diagnostics = {
-								globals = { "vim" },
-							},
-							completion = {
-								callSnippet = "Replace",
-							},
-						},
-					},
-				})
-			end,
-		})
-	end,
+    mason_lspconfig.setup_handlers({
+      -- default handler for installed servers
+      function(server_name)
+        lspconfig[server_name].setup({
+          capabilities = capabilities,
+        })
+      end,
+      ["marksman"] = function()
+        lspconfig["marksman"].setup({
+          capabilities = capabilities,
+          cmd = { "marksman", "server" },
+          filetypes = { "markdown", "mdx" },
+        })
+      end,
+      ["graphql"] = function()
+        -- configure graphql language server
+        lspconfig["graphql"].setup({
+          capabilities = capabilities,
+          filetypes = { "graphql", "gql", "svelte", "typescriptreact", "javascriptreact" },
+        })
+      end,
+      ["emmet_ls"] = function()
+        -- configure emmet language server
+        lspconfig["emmet_ls"].setup({
+          capabilities = capabilities,
+          filetypes = {
+            "html",
+            "typescriptreact",
+            "javascriptreact",
+            "css",
+            "sass",
+            "scss",
+            "less",
+            "svelte",
+          },
+        })
+      end,
+      ["lua_ls"] = function()
+        -- configure lua server (with special settings)
+        lspconfig["lua_ls"].setup({
+          capabilities = capabilities,
+          settings = {
+            Lua = {
+              -- make the language server recognize "vim" global
+              diagnostics = {
+                globals = { "vim" },
+              },
+              completion = {
+                callSnippet = "Replace",
+              },
+            },
+          },
+        })
+      end,
+    })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/lsp/lspconfig.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/lsp/lspconfig.lua
@@ -47,7 +47,7 @@ return {
         keymap.set({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, opts) -- see available code actions, in visual mode will apply to selection
 
         opts.desc = "Smart rename"
-        keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts) -- smart rename
+        keymap.set("n", "<leader>cr", vim.lsp.buf.rename, opts) -- smart rename
 
         opts.desc = "Show buffer diagnostics"
         keymap.set("n", "<leader>D", "<cmd>FzfLua diagnostics bufnr=0<CR>", opts) -- show  diagnostics for file
@@ -65,7 +65,7 @@ return {
         keymap.set("n", "K", vim.lsp.buf.hover, opts) -- show documentation for what is under cursor
 
         opts.desc = "Restart LSP"
-        keymap.set("n", "<leader>rs", ":LspRestart<CR>", opts) -- mapping to restart lsp if necessary
+        keymap.set("n", "<leader>cl", ":LspRestart<CR>", opts) -- mapping to restart lsp if necessary
       end,
     })
 

--- a/neovim/lazy-nvim/lua/jake/plugins/lsp/mason.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/lsp/mason.lua
@@ -1,56 +1,56 @@
 return {
-	-- https://github.com/williamboman/mason.nvim
-	"williamboman/mason.nvim",
-	version = "1.*",
-	dependencies = {
-		"williamboman/mason-lspconfig.nvim",
-		"WhoIsSethDaniel/mason-tool-installer.nvim",
-	},
-	config = function()
-		-- import mason
-		local mason = require("mason")
+  -- https://github.com/williamboman/mason.nvim
+  "williamboman/mason.nvim",
+  version = "1.*",
+  dependencies = {
+    "williamboman/mason-lspconfig.nvim",
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+  },
+  config = function()
+    -- import mason
+    local mason = require("mason")
 
-		-- import mason-lspconfig
-		local mason_lspconfig = require("mason-lspconfig")
+    -- import mason-lspconfig
+    local mason_lspconfig = require("mason-lspconfig")
 
-		local mason_tool_installer = require("mason-tool-installer")
+    local mason_tool_installer = require("mason-tool-installer")
 
-		-- enable mason and configure icons
-		mason.setup({
-			ui = {
-				icons = {
-					package_installed = "✓",
-					package_pending = "➜",
-					package_uninstalled = "✗",
-				},
-			},
-		})
+    -- enable mason and configure icons
+    mason.setup({
+      ui = {
+        icons = {
+          package_installed = "✓",
+          package_pending = "➜",
+          package_uninstalled = "✗",
+        },
+      },
+    })
 
-		mason_lspconfig.setup({
-			-- list of servers for mason to install
-			automatic_installation = { true },
-			ensure_installed = {
-				"ansiblels",
-				"bashls",
-				"cssls",
-				"dockerls",
-				"emmet_ls",
-				"graphql",
-				"html",
-				"lua_ls",
-				"marksman",
-				"puppet",
-				"ruff",
-				"yamlls",
-			},
-		})
+    mason_lspconfig.setup({
+      -- list of servers for mason to install
+      automatic_installation = { true },
+      ensure_installed = {
+        "ansiblels",
+        "bashls",
+        "cssls",
+        "dockerls",
+        "emmet_ls",
+        "graphql",
+        "html",
+        "lua_ls",
+        "marksman",
+        "puppet",
+        "ruff",
+        "yamlls",
+      },
+    })
 
-		mason_tool_installer.setup({
-			ensure_installed = {
-				"prettier", -- prettier formatter
-				"stylua", -- lua formatter
-				"ruff", -- python formatter
-			},
-		})
-	end,
+    mason_tool_installer.setup({
+      ensure_installed = {
+        "prettier", -- prettier formatter
+        "stylua", -- lua formatter
+        "ruff", -- python formatter
+      },
+    })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/lualine.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/lualine.lua
@@ -1,73 +1,73 @@
 return {
-	-- https://github.com/nvim-lualine/lualine.nvim
-	"nvim-lualine/lualine.nvim",
-	-- NOTE: no releases, no tags
-	dependencies = { "nvim-tree/nvim-web-devicons" },
-	config = function()
-		local lualine = require("lualine")
-		local lazy_status = require("lazy.status") -- to configure lazy pending updates count
+  -- https://github.com/nvim-lualine/lualine.nvim
+  "nvim-lualine/lualine.nvim",
+  -- NOTE: no releases, no tags
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  config = function()
+    local lualine = require("lualine")
+    local lazy_status = require("lazy.status") -- to configure lazy pending updates count
 
-		local colors = {
-			blue = "#65D1FF",
-			green = "#3EFFDC",
-			violet = "#FF61EF",
-			yellow = "#FFDA7B",
-			red = "#FF4A4A",
-			fg = "#c3ccdc",
-			bg = "#112638",
-			inactive_bg = "#2c3043",
-		}
+    local colors = {
+      blue = "#65D1FF",
+      green = "#3EFFDC",
+      violet = "#FF61EF",
+      yellow = "#FFDA7B",
+      red = "#FF4A4A",
+      fg = "#c3ccdc",
+      bg = "#112638",
+      inactive_bg = "#2c3043",
+    }
 
-		local my_lualine_theme = {
-			normal = {
-				a = { bg = colors.blue, fg = colors.bg, gui = "bold" },
-				b = { bg = colors.bg, fg = colors.fg },
-				c = { bg = colors.bg, fg = colors.fg },
-			},
-			insert = {
-				a = { bg = colors.green, fg = colors.bg, gui = "bold" },
-				b = { bg = colors.bg, fg = colors.fg },
-				c = { bg = colors.bg, fg = colors.fg },
-			},
-			visual = {
-				a = { bg = colors.violet, fg = colors.bg, gui = "bold" },
-				b = { bg = colors.bg, fg = colors.fg },
-				c = { bg = colors.bg, fg = colors.fg },
-			},
-			command = {
-				a = { bg = colors.yellow, fg = colors.bg, gui = "bold" },
-				b = { bg = colors.bg, fg = colors.fg },
-				c = { bg = colors.bg, fg = colors.fg },
-			},
-			replace = {
-				a = { bg = colors.red, fg = colors.bg, gui = "bold" },
-				b = { bg = colors.bg, fg = colors.fg },
-				c = { bg = colors.bg, fg = colors.fg },
-			},
-			inactive = {
-				a = { bg = colors.inactive_bg, fg = colors.semilightgray, gui = "bold" },
-				b = { bg = colors.inactive_bg, fg = colors.semilightgray },
-				c = { bg = colors.inactive_bg, fg = colors.semilightgray },
-			},
-		}
+    local my_lualine_theme = {
+      normal = {
+        a = { bg = colors.blue, fg = colors.bg, gui = "bold" },
+        b = { bg = colors.bg, fg = colors.fg },
+        c = { bg = colors.bg, fg = colors.fg },
+      },
+      insert = {
+        a = { bg = colors.green, fg = colors.bg, gui = "bold" },
+        b = { bg = colors.bg, fg = colors.fg },
+        c = { bg = colors.bg, fg = colors.fg },
+      },
+      visual = {
+        a = { bg = colors.violet, fg = colors.bg, gui = "bold" },
+        b = { bg = colors.bg, fg = colors.fg },
+        c = { bg = colors.bg, fg = colors.fg },
+      },
+      command = {
+        a = { bg = colors.yellow, fg = colors.bg, gui = "bold" },
+        b = { bg = colors.bg, fg = colors.fg },
+        c = { bg = colors.bg, fg = colors.fg },
+      },
+      replace = {
+        a = { bg = colors.red, fg = colors.bg, gui = "bold" },
+        b = { bg = colors.bg, fg = colors.fg },
+        c = { bg = colors.bg, fg = colors.fg },
+      },
+      inactive = {
+        a = { bg = colors.inactive_bg, fg = colors.semilightgray, gui = "bold" },
+        b = { bg = colors.inactive_bg, fg = colors.semilightgray },
+        c = { bg = colors.inactive_bg, fg = colors.semilightgray },
+      },
+    }
 
-		-- configure lualine with modified theme
-		lualine.setup({
-			options = {
-				theme = my_lualine_theme,
-			},
-			sections = {
-				lualine_x = {
-					{
-						lazy_status.updates,
-						cond = lazy_status.has_updates,
-						color = { fg = "#ff9e64" },
-					},
-					{ "encoding" },
-					{ "fileformat" },
-					{ "filetype" },
-				},
-			},
-		})
-	end,
+    -- configure lualine with modified theme
+    lualine.setup({
+      options = {
+        theme = my_lualine_theme,
+      },
+      sections = {
+        lualine_x = {
+          {
+            lazy_status.updates,
+            cond = lazy_status.has_updates,
+            color = { fg = "#ff9e64" },
+          },
+          { "encoding" },
+          { "fileformat" },
+          { "filetype" },
+        },
+      },
+    })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/luasnip.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/luasnip.lua
@@ -1,7 +1,7 @@
 return {
-	-- https://github.com/L3MON4D3/LuaSnip
-	"L3MON4D3/LuaSnip",
-	version = "v2.*",
-	-- install jsregexp (optional!).
-	-- build = "make install_jsregexp"
+  -- https://github.com/L3MON4D3/LuaSnip
+  "L3MON4D3/LuaSnip",
+  version = "v2.*",
+  -- install jsregexp (optional!).
+  -- build = "make install_jsregexp"
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/marks.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/marks.lua
@@ -1,8 +1,8 @@
 return {
-	-- https://github.com/chentoast/marks.nvim
-	"chentoast/marks.nvim",
-	-- NOTE: no releases, no tags
-	event = "VeryLazy",
-	-- https://github.com/chentoast/marks.nvim?tab=readme-ov-file#setup
-	opts = {},
+  -- https://github.com/chentoast/marks.nvim
+  "chentoast/marks.nvim",
+  -- NOTE: no releases, no tags
+  event = "VeryLazy",
+  -- https://github.com/chentoast/marks.nvim?tab=readme-ov-file#setup
+  opts = {},
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/nvim-cmp.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/nvim-cmp.lua
@@ -51,6 +51,7 @@ return {
         { name = "luasnip" }, -- snippets
         { name = "buffer" }, -- text within current buffer
         { name = "path" }, -- file system paths
+        { name = "render-markdown" },
       }),
 
       -- configure lspkind for vs-code like pictograms in completion menu

--- a/neovim/lazy-nvim/lua/jake/plugins/nvim-cmp.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/nvim-cmp.lua
@@ -1,65 +1,65 @@
 return {
-	-- https://github.com/hrsh7th/nvim-cmp
-	"hrsh7th/nvim-cmp",
-	-- NOTE: dev stopped using releases, no tags
-	event = "InsertEnter",
-	dependencies = {
-		"hrsh7th/cmp-buffer", -- source for text in buffer
-		"hrsh7th/cmp-path", -- source for file system paths
-		{
-			"L3MON4D3/LuaSnip",
-			-- follow latest release.
-			version = "2.*",
-			-- install jsregexp (optional!).
-			build = "make install_jsregexp",
-		},
-		"saadparwaiz1/cmp_luasnip", -- for autocompletion
-		"rafamadriz/friendly-snippets", -- useful snippets
-		"onsails/lspkind.nvim", -- vs-code like pictograms
-	},
-	config = function()
-		local cmp = require("cmp")
+  -- https://github.com/hrsh7th/nvim-cmp
+  "hrsh7th/nvim-cmp",
+  -- NOTE: dev stopped using releases, no tags
+  event = "InsertEnter",
+  dependencies = {
+    "hrsh7th/cmp-buffer", -- source for text in buffer
+    "hrsh7th/cmp-path", -- source for file system paths
+    {
+      "L3MON4D3/LuaSnip",
+      -- follow latest release.
+      version = "2.*",
+      -- install jsregexp (optional!).
+      build = "make install_jsregexp",
+    },
+    "saadparwaiz1/cmp_luasnip", -- for autocompletion
+    "rafamadriz/friendly-snippets", -- useful snippets
+    "onsails/lspkind.nvim", -- vs-code like pictograms
+  },
+  config = function()
+    local cmp = require("cmp")
 
-		local luasnip = require("luasnip")
+    local luasnip = require("luasnip")
 
-		local lspkind = require("lspkind")
+    local lspkind = require("lspkind")
 
-		-- loads vscode style snippets from installed plugins (e.g. friendly-snippets)
-		require("luasnip.loaders.from_vscode").lazy_load()
+    -- loads vscode style snippets from installed plugins (e.g. friendly-snippets)
+    require("luasnip.loaders.from_vscode").lazy_load()
 
-		cmp.setup({
-			completion = {
-				completeopt = "menu,menuone,preview,noselect",
-			},
-			snippet = { -- configure how nvim-cmp interacts with snippet engine
-				expand = function(args)
-					luasnip.lsp_expand(args.body)
-				end,
-			},
-			mapping = cmp.mapping.preset.insert({
-				["<C-k>"] = cmp.mapping.select_prev_item(), -- previous suggestion
-				["<C-j>"] = cmp.mapping.select_next_item(), -- next suggestion
-				["<C-b>"] = cmp.mapping.scroll_docs(-4),
-				["<C-f>"] = cmp.mapping.scroll_docs(4),
-				["<C-Space>"] = cmp.mapping.complete(), -- show completion suggestions
-				["<C-e>"] = cmp.mapping.abort(), -- close completion window
-				["<CR>"] = cmp.mapping.confirm({ select = false }),
-			}),
-			-- sources for autocompletion
-			sources = cmp.config.sources({
-				{ name = "nvim_lsp" },
-				{ name = "luasnip" }, -- snippets
-				{ name = "buffer" }, -- text within current buffer
-				{ name = "path" }, -- file system paths
-			}),
+    cmp.setup({
+      completion = {
+        completeopt = "menu,menuone,preview,noselect",
+      },
+      snippet = { -- configure how nvim-cmp interacts with snippet engine
+        expand = function(args)
+          luasnip.lsp_expand(args.body)
+        end,
+      },
+      mapping = cmp.mapping.preset.insert({
+        ["<C-k>"] = cmp.mapping.select_prev_item(), -- previous suggestion
+        ["<C-j>"] = cmp.mapping.select_next_item(), -- next suggestion
+        ["<C-b>"] = cmp.mapping.scroll_docs(-4),
+        ["<C-f>"] = cmp.mapping.scroll_docs(4),
+        ["<C-Space>"] = cmp.mapping.complete(), -- show completion suggestions
+        ["<C-e>"] = cmp.mapping.abort(), -- close completion window
+        ["<CR>"] = cmp.mapping.confirm({ select = false }),
+      }),
+      -- sources for autocompletion
+      sources = cmp.config.sources({
+        { name = "nvim_lsp" },
+        { name = "luasnip" }, -- snippets
+        { name = "buffer" }, -- text within current buffer
+        { name = "path" }, -- file system paths
+      }),
 
-			-- configure lspkind for vs-code like pictograms in completion menu
-			formatting = {
-				format = lspkind.cmp_format({
-					maxwidth = 50,
-					ellipsis_char = "...",
-				}),
-			},
-		})
-	end,
+      -- configure lspkind for vs-code like pictograms in completion menu
+      formatting = {
+        format = lspkind.cmp_format({
+          maxwidth = 50,
+          ellipsis_char = "...",
+        }),
+      },
+    })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/nvim-surround.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/nvim-surround.lua
@@ -1,8 +1,8 @@
 return {
-	-- https://github.com/kylechui/nvim-surround
-	"kylechui/nvim-surround",
-	version = "2.*",
-	event = { "BufReadPre", "BufNewFile" },
-	version = "*", -- Use for stability; omit to use `main` branch for the latest features
-	config = true,
+  -- https://github.com/kylechui/nvim-surround
+  "kylechui/nvim-surround",
+  version = "2.*",
+  event = { "BufReadPre", "BufNewFile" },
+  version = "*", -- Use for stability; omit to use `main` branch for the latest features
+  config = true,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/nvim-tree.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/nvim-tree.lua
@@ -1,63 +1,58 @@
 return {
-	-- https://github.com/nvim-tree/nvim-tree.lua
-	"nvim-tree/nvim-tree.lua",
-	version = "1.*",
-	dependencies = "nvim-tree/nvim-web-devicons",
-	config = function()
-		local nvimtree = require("nvim-tree")
+  -- https://github.com/nvim-tree/nvim-tree.lua
+  "nvim-tree/nvim-tree.lua",
+  version = "1.*",
+  dependencies = "nvim-tree/nvim-web-devicons",
+  config = function()
+    local nvimtree = require("nvim-tree")
 
-		-- recommended settings from nvim-tree documentation
-		vim.g.loaded_netrw = 1
-		vim.g.loaded_netrwPlugin = 1
+    -- recommended settings from nvim-tree documentation
+    vim.g.loaded_netrw = 1
+    vim.g.loaded_netrwPlugin = 1
 
-		nvimtree.setup({
-			view = {
-				width = 35,
-				relativenumber = true,
-			},
-			-- change folder arrow icons
-			renderer = {
-				indent_markers = {
-					enable = true,
-				},
-				icons = {
-					glyphs = {
-						folder = {
-							arrow_closed = "", -- arrow when folder is closed
-							arrow_open = "", -- arrow when folder is open
-						},
-					},
-				},
-			},
-			-- disable window_picker for
-			-- explorer to work well with
-			-- window splits
-			actions = {
-				open_file = {
-					window_picker = {
-						enable = false,
-					},
-				},
-			},
-			filters = {
-				custom = { ".DS_Store" },
-			},
-			git = {
-				ignore = false,
-			},
-		})
+    nvimtree.setup({
+      view = {
+        width = 35,
+        relativenumber = true,
+      },
+      -- change folder arrow icons
+      renderer = {
+        indent_markers = {
+          enable = true,
+        },
+        icons = {
+          glyphs = {
+            folder = {
+              arrow_closed = "", -- arrow when folder is closed
+              arrow_open = "", -- arrow when folder is open
+            },
+          },
+        },
+      },
+      -- disable window_picker for
+      -- explorer to work well with
+      -- window splits
+      actions = {
+        open_file = {
+          window_picker = {
+            enable = false,
+          },
+        },
+      },
+      filters = {
+        custom = { ".DS_Store" },
+      },
+      git = {
+        ignore = false,
+      },
+    })
 
-		-- set keymaps
-		local keymap = vim.keymap -- for conciseness
+    -- set keymaps
+    local keymap = vim.keymap -- for conciseness
 
-		keymap.set("n", "<leader>ee", "<cmd>NvimTreeToggle<CR>", { desc = "Toggle file explorer" }) -- toggle file explorer
-		keymap.set(
-			"n",
-			"<leader>ef",
-			"<cmd>NvimTreeFindFileToggle<CR>",
-			{ desc = "Toggle file explorer on current file" }
-		) -- toggle file explorer on current file
-		keymap.set("n", "<leader>ec", "<cmd>NvimTreeCollapse<CR>", { desc = "Collapse file explorer" }) -- collapse file explorer
-		keymap.set("n", "<leader>er", "<cmd>NvimTreeRefresh<CR>", { desc = "Refresh file explorer" }) -- refresh file explorer
-	end,
+    keymap.set("n", "<leader>ee", "<cmd>NvimTreeToggle<CR>", { desc = "Toggle file explorer" }) -- toggle file explorer
+    keymap.set("n", "<leader>ef", "<cmd>NvimTreeFindFileToggle<CR>", { desc = "Toggle file explorer on current file" }) -- toggle file explorer on current file
+    keymap.set("n", "<leader>ec", "<cmd>NvimTreeCollapse<CR>", { desc = "Collapse file explorer" }) -- collapse file explorer
+    keymap.set("n", "<leader>er", "<cmd>NvimTreeRefresh<CR>", { desc = "Refresh file explorer" }) -- refresh file explorer
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/obsidian.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/obsidian.lua
@@ -1,0 +1,148 @@
+return {
+  "epwalsh/obsidian.nvim",
+  version = "3.*", -- recommended, use latest release instead of latest commit
+  lazy = true,
+  ft = "markdown",
+  -- Replace the above line with this if you only want to load obsidian.nvim for markdown files in your vault:
+  -- event = {
+  --   -- If you want to use the home shortcut '~' here you need to call 'vim.fn.expand'.
+  --   -- E.g. "BufReadPre " .. vim.fn.expand "~" .. "/my-vault/*.md"
+  --   -- refer to `:h file-pattern` for more examples
+  --   "BufReadPre path/to/my-vault/*.md",
+  --   "BufNewFile path/to/my-vault/*.md",
+  -- },
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+  },
+
+  opts = {
+    -- A list of workspace names, paths, and configuration overrides.
+    -- If you use the Obsidian app, the 'path' of a workspace should generally be
+    -- your vault root (where the `.obsidian` folder is located).
+    -- When obsidian.nvim is loaded by your plugin manager, it will automatically set
+    -- the workspace to the first workspace in the list whose `path` is a parent of the
+    -- current markdown file being edited.
+    workspaces = (function()
+      local Path = require("plenary.path")
+      local my_workspaces = {}
+
+      if Path:new("/mnt/WORK/obsidian"):exists() then
+        table.insert(my_workspaces, { path = "/mnt/WORK/obsidian", name = "personal" })
+      end
+
+      if Path:new("~/documents/documentation"):exists() then
+        table.insert(my_workspaces, { path = "~/documents/documentation", name = "work" })
+      end
+
+      return my_workspaces
+    end)(),
+
+    -- Optional, set the log level for obsidian.nvim. This is an integer corresponding to one of the log
+    -- levels defined by "vim.log.levels.*".
+    log_level = vim.log.levels.INFO,
+
+    daily_notes = {
+      -- Optional, if you keep daily notes in a separate directory.
+      -- folder = "notes/dailies",
+      -- Optional, if you want to change the date format for the ID of daily notes.
+      date_format = "%Y-%m-%d",
+      -- Optional, if you want to change the date format of the default alias of daily notes.
+      alias_format = "%B %-d, %Y",
+      -- Optional, default tags to add to each new daily note created.
+      default_tags = { "daily-notes" },
+      -- Optional, if you want to automatically insert a template from your template directory like 'daily.md'
+      template = nil,
+    },
+
+    -- Optional, completion of wiki links, local markdown links, and tags using nvim-cmp.
+    completion = {
+      -- Set to false to disable completion.
+      nvim_cmp = true,
+      -- Trigger completion at 2 chars.
+      min_chars = 2,
+    },
+
+    mappings = {
+      -- Overrides the 'gf' mapping to work on markdown/wiki links within your vault.
+      ["gf"] = {
+        action = function()
+          return require("obsidian").util.gf_passthrough()
+        end,
+        opts = { noremap = false, expr = true, buffer = true },
+      },
+      -- Toggle check-boxes.
+      ["<leader>oh"] = {
+        action = function()
+          return require("obsidian").util.toggle_checkbox()
+        end,
+        opts = { buffer = true },
+      },
+      -- Smart action depending on context, either follow link or toggle checkbox.
+      ["<leader>or"] = {
+        action = function()
+          return require("obsidian").util.smart_action()
+        end,
+        opts = { buffer = true, expr = true },
+      },
+    },
+
+    -- Where to put new notes. Valid options are
+    --  * "current_dir" - put new notes in same directory as the current buffer.
+    --  * "notes_subdir" - put new notes in the default notes subdirectory.
+    new_notes_location = "current_dir",
+
+    -- Either 'wiki' or 'markdown'.
+    preferred_link_style = "wiki",
+
+    -- Optional, boolean or a function that takes a filename and returns a boolean.
+    -- `true` indicates that you don't want obsidian.nvim to manage frontmatter.
+    disable_frontmatter = false,
+
+    -- Optional, for templates (see below).
+    templates = {
+      folder = "templates",
+      date_format = "%Y-%m-%d",
+      time_format = "%H:%M",
+      -- A map for custom variables, the key should be the variable and the value a function
+      substitutions = {},
+    },
+
+    picker = {
+      -- Set your preferred picker. Can be one of 'telescope.nvim', 'fzf-lua', or 'mini.pick'.
+      name = "fzf-lua",
+      -- Optional, configure key mappings for the picker. These are the defaults.
+      -- Not all pickers support all mappings.
+      note_mappings = {
+        -- Create a new note from your query.
+        new = "<C-x>",
+        -- Insert a link to the selected note.
+        insert_link = "<C-l>",
+      },
+      tag_mappings = {
+        -- Add tag(s) to current note.
+        tag_note = "<C-x>",
+        -- Insert a tag at the current location.
+        insert_tag = "<C-l>",
+      },
+    },
+
+    -- Optional, sort search results by "path", "modified", "accessed", or "created".
+    -- The recommend value is "modified" and `true` for `sort_reversed`, which means, for example,
+    -- that `:ObsidianQuickSwitch` will show the notes sorted by latest modified time
+    sort_by = "modified",
+    sort_reversed = true,
+
+    -- Set the maximum number of lines to read from notes on disk when performing certain searches.
+    search_max_lines = 1000,
+
+    -- Optional, determines how certain commands open notes. The valid options are:
+    -- 1. "current" (the default) - to always open in the current window
+    -- 2. "vsplit" - to open in a vertical split if there's not already a vertical split
+    -- 3. "hsplit" - to open in a horizontal split if there's not already a horizontal split
+    open_notes_in = "current",
+
+    ui = {
+      enable = false, -- set to false to disable all additional syntax features
+    },
+  },
+}

--- a/neovim/lazy-nvim/lua/jake/plugins/render-markdown.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/render-markdown.lua
@@ -1,68 +1,68 @@
 return {
-	-- https://github.com/MeanderingProgrammer/markdown.nvim
-	"MeanderingProgrammer/markdown.nvim",
-	version = "7.*",
-	dependencies = {
-		"nvim-treesitter/nvim-treesitter",
-		"nvim-tree/nvim-web-devicons",
-	}, -- if you use the mini.nvim suite
+  -- https://github.com/MeanderingProgrammer/markdown.nvim
+  "MeanderingProgrammer/markdown.nvim",
+  version = "7.*",
+  dependencies = {
+    "nvim-treesitter/nvim-treesitter",
+    "nvim-tree/nvim-web-devicons",
+  }, -- if you use the mini.nvim suite
 
-	opts = {
-		bullet = {
-			-- Turn on / off list bullet rendering
-			enabled = true,
-		},
-		checkbox = {
-			-- Turn on / off checkbox state rendering
-			enabled = true,
-			-- Determines how icons fill the available space:
-			--  inline:  underlying text is concealed resulting in a left aligned icon
-			--  overlay: result is left padded with spaces to hide any additional text
-			position = "inline",
-			unchecked = {
-				-- Replaces '[ ]' of 'task_list_marker_unchecked'
-				icon = "   󰄱 ",
-				-- Highlight for the unchecked icon
-				highlight = "RenderMarkdownUnchecked",
-				-- Highlight for item associated with unchecked checkbox
-				scope_highlight = nil,
-			},
-			checked = {
-				-- Replaces '[x]' of 'task_list_marker_checked'
-				icon = "   󰱒 ",
-				-- Highlight for the checked icon
-				highlight = "RenderMarkdownChecked",
-				-- Highlight for item associated with checked checkbox
-				scope_highlight = nil,
-			},
-		},
-		html = {
-			-- Turn on / off all HTML rendering
-			enabled = true,
-			comment = {
-				-- Turn on / off HTML comment concealing
-				conceal = false,
-			},
-		},
-		heading = {
-			sign = false,
-			icons = { "󰎤 ", "󰎧 ", "󰎪 ", "󰎭 ", "󰎱 ", "󰎳 " },
-			-- backgrounds = {
-			-- 	"Headline1Bg",
-			-- 	"Headline2Bg",
-			-- 	"Headline3Bg",
-			-- 	"Headline4Bg",
-			-- 	"Headline5Bg",
-			-- 	"Headline6Bg",
-			-- },
-			-- foregrounds = {
-			-- 	"Headline1Fg",
-			-- 	"Headline2Fg",
-			-- 	"Headline3Fg",
-			-- 	"Headline4Fg",
-			-- 	"Headline5Fg",
-			-- 	"Headline6Fg",
-			-- },
-		},
-	},
+  opts = {
+    bullet = {
+      -- Turn on / off list bullet rendering
+      enabled = true,
+    },
+    checkbox = {
+      -- Turn on / off checkbox state rendering
+      enabled = true,
+      -- Determines how icons fill the available space:
+      --  inline:  underlying text is concealed resulting in a left aligned icon
+      --  overlay: result is left padded with spaces to hide any additional text
+      position = "inline",
+      unchecked = {
+        -- Replaces '[ ]' of 'task_list_marker_unchecked'
+        icon = "   󰄱 ",
+        -- Highlight for the unchecked icon
+        highlight = "RenderMarkdownUnchecked",
+        -- Highlight for item associated with unchecked checkbox
+        scope_highlight = nil,
+      },
+      checked = {
+        -- Replaces '[x]' of 'task_list_marker_checked'
+        icon = "   󰱒 ",
+        -- Highlight for the checked icon
+        highlight = "RenderMarkdownChecked",
+        -- Highlight for item associated with checked checkbox
+        scope_highlight = nil,
+      },
+    },
+    html = {
+      -- Turn on / off all HTML rendering
+      enabled = true,
+      comment = {
+        -- Turn on / off HTML comment concealing
+        conceal = false,
+      },
+    },
+    heading = {
+      sign = false,
+      icons = { "󰎤 ", "󰎧 ", "󰎪 ", "󰎭 ", "󰎱 ", "󰎳 " },
+      -- backgrounds = {
+      -- 	"Headline1Bg",
+      -- 	"Headline2Bg",
+      -- 	"Headline3Bg",
+      -- 	"Headline4Bg",
+      -- 	"Headline5Bg",
+      -- 	"Headline6Bg",
+      -- },
+      -- foregrounds = {
+      -- 	"Headline1Fg",
+      -- 	"Headline2Fg",
+      -- 	"Headline3Fg",
+      -- 	"Headline4Fg",
+      -- 	"Headline5Fg",
+      -- 	"Headline6Fg",
+      -- },
+    },
+  },
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/substitute.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/substitute.lua
@@ -1,19 +1,19 @@
 return {
-	-- https://github.com/gbprod/substitute.nvim
-	"gbprod/substitute.nvim",
-	version = "2.*",
-	event = { "BufReadPre", "BufNewFile" },
-	config = function()
-		local substitute = require("substitute")
+  -- https://github.com/gbprod/substitute.nvim
+  "gbprod/substitute.nvim",
+  version = "2.*",
+  event = { "BufReadPre", "BufNewFile" },
+  config = function()
+    local substitute = require("substitute")
 
-		substitute.setup()
+    substitute.setup()
 
-		-- set keymaps
-		local keymap = vim.keymap -- for conciseness
+    -- set keymaps
+    local keymap = vim.keymap -- for conciseness
 
-		vim.keymap.set("n", "s", substitute.operator, { desc = "Substitute with motion" })
-		vim.keymap.set("n", "ss", substitute.line, { desc = "Substitute line" })
-		vim.keymap.set("n", "S", substitute.eol, { desc = "Substitute to end of line" })
-		vim.keymap.set("x", "s", substitute.visual, { desc = "Substitute in visual mode" })
-	end,
+    vim.keymap.set("n", "s", substitute.operator, { desc = "Substitute with motion" })
+    vim.keymap.set("n", "ss", substitute.line, { desc = "Substitute line" })
+    vim.keymap.set("n", "S", substitute.eol, { desc = "Substitute to end of line" })
+    vim.keymap.set("x", "s", substitute.visual, { desc = "Substitute in visual mode" })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/todo-comments.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/todo-comments.lua
@@ -1,23 +1,23 @@
 return {
-	-- https://github.com/folke/todo-comments.nvim
-	"folke/todo-comments.nvim",
-	version = "1.*",
-	event = { "BufReadPre", "BufNewFile" },
-	dependencies = { "nvim-lua/plenary.nvim" },
-	config = function()
-		local todo_comments = require("todo-comments")
+  -- https://github.com/folke/todo-comments.nvim
+  "folke/todo-comments.nvim",
+  version = "1.*",
+  event = { "BufReadPre", "BufNewFile" },
+  dependencies = { "nvim-lua/plenary.nvim" },
+  config = function()
+    local todo_comments = require("todo-comments")
 
-		-- set keymaps
-		local keymap = vim.keymap -- for conciseness
+    -- set keymaps
+    local keymap = vim.keymap -- for conciseness
 
-		keymap.set("n", "]t", function()
-			todo_comments.jump_next()
-		end, { desc = "Next todo comment" })
+    keymap.set("n", "]t", function()
+      todo_comments.jump_next()
+    end, { desc = "Next todo comment" })
 
-		keymap.set("n", "[t", function()
-			todo_comments.jump_prev()
-		end, { desc = "Previous todo comment" })
+    keymap.set("n", "[t", function()
+      todo_comments.jump_prev()
+    end, { desc = "Previous todo comment" })
 
-		todo_comments.setup()
-	end,
+    todo_comments.setup()
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/treesitter.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/treesitter.lua
@@ -1,65 +1,65 @@
 return {
-	-- https://github.com/nvim-treesitter/nvim-treesitter
-	"nvim-treesitter/nvim-treesitter",
-	-- NOTE: no releases, tags only
-	event = { "BufReadPre", "BufNewFile" },
-	build = ":TSUpdate",
-	dependencies = {
-		"windwp/nvim-ts-autotag",
-	},
-	config = function()
-		-- import nvim-treesitter plugin
-		local treesitter = require("nvim-treesitter.configs")
+  -- https://github.com/nvim-treesitter/nvim-treesitter
+  "nvim-treesitter/nvim-treesitter",
+  -- NOTE: no releases, tags only
+  event = { "BufReadPre", "BufNewFile" },
+  build = ":TSUpdate",
+  dependencies = {
+    "windwp/nvim-ts-autotag",
+  },
+  config = function()
+    -- import nvim-treesitter plugin
+    local treesitter = require("nvim-treesitter.configs")
 
-		-- configure treesitter
-		treesitter.setup({ -- enable syntax highlighting
-			highlight = {
-				enable = true,
-			},
-			-- enable indentation
-			indent = { enable = true },
-			-- enable autotagging (w/ nvim-ts-autotag plugin)
-			autotag = {
-				enable = true,
-			},
-			-- ensure these language parsers are installed
-			ensure_installed = {
-				"bash",
-				"c",
-				"css",
-				"csv",
-				"diff",
-				"dockerfile",
-				"gitignore",
-				"go",
-				"gpg",
-				"graphql",
-				"helm",
-				"html",
-				"javascript",
-				"json",
-				"lua",
-				"markdown",
-				"markdown_inline",
-				"puppet",
-				"python",
-				"query",
-				"ruby",
-				"tsx",
-				"typescript",
-				"vim",
-				"vimdoc",
-				"yaml",
-			},
-			incremental_selection = {
-				enable = true,
-				keymaps = {
-					init_selection = "<C-space>",
-					node_incremental = "<C-space>",
-					scope_incremental = false,
-					node_decremental = "<bs>",
-				},
-			},
-		})
-	end,
+    -- configure treesitter
+    treesitter.setup({ -- enable syntax highlighting
+      highlight = {
+        enable = true,
+      },
+      -- enable indentation
+      indent = { enable = true },
+      -- enable autotagging (w/ nvim-ts-autotag plugin)
+      autotag = {
+        enable = true,
+      },
+      -- ensure these language parsers are installed
+      ensure_installed = {
+        "bash",
+        "c",
+        "css",
+        "csv",
+        "diff",
+        "dockerfile",
+        "gitignore",
+        "go",
+        "gpg",
+        "graphql",
+        "helm",
+        "html",
+        "javascript",
+        "json",
+        "lua",
+        "markdown",
+        "markdown_inline",
+        "puppet",
+        "python",
+        "query",
+        "ruby",
+        "tsx",
+        "typescript",
+        "vim",
+        "vimdoc",
+        "yaml",
+      },
+      incremental_selection = {
+        enable = true,
+        keymaps = {
+          init_selection = "<C-space>",
+          node_incremental = "<C-space>",
+          scope_incremental = false,
+          node_decremental = "<bs>",
+        },
+      },
+    })
+  end,
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/trouble.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/trouble.lua
@@ -1,21 +1,21 @@
 return {
-	-- https://github.com/folke/trouble.nvim
-	"folke/trouble.nvim",
-	version = "3.*",
-	dependencies = { "nvim-tree/nvim-web-devicons", "folke/todo-comments.nvim" },
-	opts = {
-		focus = true,
-	},
-	cmd = "Trouble",
-	keys = {
-		{ "<leader>xw", "<cmd>Trouble diagnostics toggle<CR>", desc = "Open trouble workspace diagnostics" },
-		{
-			"<leader>xd",
-			"<cmd>Trouble diagnostics toggle filter.buf=0<CR>",
-			desc = "Open trouble document diagnostics",
-		},
-		{ "<leader>xq", "<cmd>Trouble quickfix toggle<CR>", desc = "Open trouble quickfix list" },
-		{ "<leader>xl", "<cmd>Trouble loclist toggle<CR>", desc = "Open trouble location list" },
-		{ "<leader>xt", "<cmd>Trouble todo toggle<CR>", desc = "Open todos in trouble" },
-	},
+  -- https://github.com/folke/trouble.nvim
+  "folke/trouble.nvim",
+  version = "3.*",
+  dependencies = { "nvim-tree/nvim-web-devicons", "folke/todo-comments.nvim" },
+  opts = {
+    focus = true,
+  },
+  cmd = "Trouble",
+  keys = {
+    { "<leader>xw", "<cmd>Trouble diagnostics toggle<CR>", desc = "Open trouble workspace diagnostics" },
+    {
+      "<leader>xd",
+      "<cmd>Trouble diagnostics toggle filter.buf=0<CR>",
+      desc = "Open trouble document diagnostics",
+    },
+    { "<leader>xq", "<cmd>Trouble quickfix toggle<CR>", desc = "Open trouble quickfix list" },
+    { "<leader>xl", "<cmd>Trouble loclist toggle<CR>", desc = "Open trouble location list" },
+    { "<leader>xt", "<cmd>Trouble todo toggle<CR>", desc = "Open todos in trouble" },
+  },
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/vim-maximizer.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/vim-maximizer.lua
@@ -1,8 +1,8 @@
 return {
-	-- https://github.com/szw/vim-maximizer
-	"szw/vim-maximizer",
-	-- NOTE: no releases, no tags, no updates in 10+ years
-	keys = {
-		{ "<leader>sm", "<cmd>MaximizerToggle<CR>", desc = "Maximize/minimize a split" },
-	},
+  -- https://github.com/szw/vim-maximizer
+  "szw/vim-maximizer",
+  -- NOTE: no releases, no tags, no updates in 10+ years
+  keys = {
+    { "<leader>sm", "<cmd>MaximizerToggle<CR>", desc = "Maximize/minimize a split" },
+  },
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/which-key.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/which-key.lua
@@ -1,15 +1,15 @@
 return {
-	-- https://github.com/folke/which-key.nvim
-	"folke/which-key.nvim",
-	version = "3.*",
-	event = "VeryLazy",
-	init = function()
-		vim.o.timeout = true
-		vim.o.timeoutlen = 500
-	end,
-	opts = {
-		-- your configuration comes here
-		-- or leave it empty to use the default settings
-		-- refer to the configuration section below
-	},
+  -- https://github.com/folke/which-key.nvim
+  "folke/which-key.nvim",
+  version = "3.*",
+  event = "VeryLazy",
+  init = function()
+    vim.o.timeout = true
+    vim.o.timeoutlen = 500
+  end,
+  opts = {
+    -- your configuration comes here
+    -- or leave it empty to use the default settings
+    -- refer to the configuration section below
+  },
 }

--- a/neovim/lazy-nvim/lua/jake/plugins/which-key.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/which-key.lua
@@ -11,5 +11,30 @@ return {
     -- your configuration comes here
     -- or leave it empty to use the default settings
     -- refer to the configuration section below
+    spec = {
+      {
+        mode = { "n" },
+        { "<leader>c", group = "code", icon = { icon = "", color = "green" } },
+        { "<leader>cs", group = "spelling", icon = { icon = "󰓆", color = "green" } },
+        { "<leader>e", group = "explorer", icon = { icon = "󱧼", color = "blue" } },
+        { "<leader>f", group = "fzf", icon = { icon = "", color = "yellow" } },
+        { "<leader>g", group = "git", icon = { icon = "󰊢", color = "cyan" } },
+        { "<leader>h", group = "git hunk", icon = { icon = "", color = "grey" } },
+        { "<leader>m", group = "markdown", icon = { icon = "", color = "green" } },
+        { "<leader>s", group = "screen", icon = { icon = "", color = "azure" } },
+        { "<leader>t", group = "tabs", icon = { icon = "󰝜", color = "purple" } },
+        { "<leader>q", group = "quit/session", icon = { icon = "󰈆", color = "red" } },
+        { "<leader>x", group = "trouble", icon = { icon = "󰚑", color = "orange" } },
+      },
+    },
+  },
+  keys = {
+    {
+      "<leader>?",
+      function()
+        require("which-key").show({ global = false })
+      end,
+      desc = "Buffer Local Keymaps (which-key)",
+    },
   },
 }


### PR DESCRIPTION
### Plugin Additions:
* Added a new plugin `bullets.vim` for automatically adding bullet points in markdown and text files in `neovim/lazy-nvim/lua/jake/plugins/bullets.lua`.
* Added key mappings for the `TodoFzfLua` plugin to find TODOs in the current working directory in `neovim/lazy-nvim/lua/jake/plugins/fzf.lua`.

### Key Mappings Updates:
* Changed the key mapping for clearing search highlights from `<leader>nh` to `<leader>ch` in `neovim/lazy-nvim/lua/jake/core/keymaps.lua`.
* Updated key mappings for resizing windows and enabling/disabling spell check in `neovim/lazy-nvim/lua/jake/core/keymaps.lua`.
* Modified key mappings for session management from `<leader>wr` and `<leader>ws` to `<leader>qr` and `<leader>qs` respectively in `neovim/lazy-nvim/lua/jake/plugins/auto-session.lua`.
* Updated key mappings for LSP functionalities such as smart rename and restarting LSP in `neovim/lazy-nvim/lua/jake/plugins/lsp/lspconfig.lua`. [[1]](diffhunk://#diff-4ccdfbebeacab4f1c20ded839c6d7896de6d68f56041b20ecdc6dc690ef21d12L50-R50) [[2]](diffhunk://#diff-4ccdfbebeacab4f1c20ded839c6d7896de6d68f56041b20ecdc6dc690ef21d12L68-R68)
* Corrected the key mappings for navigating git hunks in `neovim/lazy-nvim/lua/jake/plugins/gitsigns.lua`.

### Other Fixes and Updates:
* Removed the use of the system clipboard as the default register in `neovim/lazy-nvim/lua/jake/core/options.lua`.
* Corrected the spelling options configuration in `neovim/lazy-nvim/lua/jake/core/options.lua`.