### PR TITLE
fix autosuggest incompatibility with zsh magic functions

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.6.0
+  version: 2.6.1
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.6.1 (2025-02-16)
+
+### Fix
+
+- **omz**: DISABLE_MAGIC_FUNCTIONS to address incompatibility with autocomplete plugin
+
 ## v2.6.0 (2025-02-06)
 
 ### Feature

--- a/omz/zshrc
+++ b/omz/zshrc
@@ -42,7 +42,7 @@ zstyle ':omz:update' mode reminder  # just remind me to update when it's time
 zstyle ':omz:update' frequency 30
 
 # Uncomment the following line if pasting URLs and other text is messed up.
-# DISABLE_MAGIC_FUNCTIONS="true"
+DISABLE_MAGIC_FUNCTIONS="true"
 
 # Uncomment the following line to disable colors in ls.
 # DISABLE_LS_COLORS="true"


### PR DESCRIPTION
Configuration changes:
* [`omz/zshrc`](diffhunk://#diff-1b6e3e98c4386a36de7a043445b6c3ac9cfad8d8e1b493e57f90499c2d07a0bfL45-R45): Uncommented the `DISABLE_MAGIC_FUNCTIONS` setting to address the incompatibility issue with the autocomplete plugin.