### PR TITLE
Bump Neovim Mason from 1 to 2.y

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.6.1
+  version: 2.6.2
   version_scheme: semver

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_install_hook_types:
   - commit-msg
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 27499d727f5ceff802bda34bbda314644824ce06  # frozen: v4.1.0
+    rev: be02801f92cb948ba86d8c1a9a306be4172e4efe  # frozen: v4.7.0
     hooks:
       - id: commitizen
         stages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.6.2 (2025-05-10)
+
+### Fix
+
+- **nvim**: update mason.nvim to version 2.* and adjust dependencies
+
 ## v2.6.1 (2025-02-16)
 
 ### Fix

--- a/neovim/lazy-nvim/lua/jake/plugins/lsp/mason.lua
+++ b/neovim/lazy-nvim/lua/jake/plugins/lsp/mason.lua
@@ -1,9 +1,9 @@
 return {
-  -- https://github.com/williamboman/mason.nvim
-  "williamboman/mason.nvim",
-  version = "1.*",
+  -- https://github.com/mason-org/mason.nvim
+  "mason-org/mason.nvim",
+  version = "2.*",
   dependencies = {
-    "williamboman/mason-lspconfig.nvim",
+    "mason-org/mason-lspconfig.nvim",
     "WhoIsSethDaniel/mason-tool-installer.nvim",
   },
   config = function()


### PR DESCRIPTION
The changes focus on updating the `mason.nvim` plugin and its dependencies, aligning with the latest versions, and ensuring the project configuration reflects these updates.

### Dependency Updates:

* Updated the `mason.nvim` plugin to version `2.*` and changed the repository reference from `williamboman` to `mason-org` in `neovim/lazy-nvim/lua/jake/plugins/lsp/mason.lua`. Adjusted dependencies accordingly.

### Configuration Updates:

* Updated the `commitizen` pre-commit hook version in `.pre-commit-config.yaml` from `v4.1.0` to `v4.7.0`.