### PR TITLE
Fix lspconfig syntax error caused by breaking mason-lspconfig v2 api change

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.6.2
+  version: 2.6.3
   version_scheme: semver

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_install_hook_types:
   - commit-msg
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: be02801f92cb948ba86d8c1a9a306be4172e4efe  # frozen: v4.7.0
+    rev: a0cc4901b0faaced74c713a9e355555fc4de0880  # frozen: v4.7.1
     hooks:
       - id: commitizen
         stages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.6.3 (2025-05-18)
+
+### Fix
+
+- **nvim**: update nvim-lspconfig version to 2.* and adjust config syntax to support mason-lspconfig v2
+
 ## v2.6.2 (2025-05-10)
 
 ### Fix


### PR DESCRIPTION
### Neovim LSP Configuration Improvements:
* Updated `nvim-lspconfig` version from `1.*` to `2.*` in `lspconfig.lua` to support compatibility with `mason-lspconfig` v2 and added `williamboman/mason-lspconfig.nvim` as a dependency.
* Refactored the LSP server setup in `lspconfig.lua` to dynamically configure installed servers using `mason_lspconfig.get_installed_servers()` and simplified the handler logic for specific servers like `marksman`, `graphql`, `emmet_ls`, and `lua_ls`.