### PR TITLE
add script to manage kube configs

### DIFF
--- a/omz/configure.sh
+++ b/omz/configure.sh
@@ -47,3 +47,16 @@ fi
 for completion in "${DOTFILES_LOCATION}/omz/completions"/*; do
   ln -sf "${completion}" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions/$(basename ${completion})"
 done
+
+### SETUP CUSTOM SCRIPTS ###
+# remove any dead symlinks from the custom completions directory or create it if it doesn't exist
+if [ -e "${HOME}/bin" ]; then
+  find "${HOME}/bin" -type l ! -exec test -e {} \; -delete
+else
+  mkdir "${HOME}/bin"
+fi
+
+# loop over all custom scripts and symlink them
+for custom_script in "${DOTFILES_LOCATION}/omz/scripts"/*; do
+  ln -sf "${custom_script}" "${HOME}/bin/$(basename ${custom_script})"
+done

--- a/omz/scripts/merge_kube_configs.zsh
+++ b/omz/scripts/merge_kube_configs.zsh
@@ -1,0 +1,31 @@
+#!/usr/bin/env zsh
+# This script merges multiple Kubernetes configuration files into a single file.
+
+set -euo pipefail
+
+# Define source and output
+source_dir="${HOME}/.kube/configs"
+output_file="${HOME}/.kube/config"
+
+# Ensure source dir exists
+if [[ ! -d "$source_dir" ]]; then
+  echo "Config directory not found: $source_dir" >&2
+  exit 1
+fi
+
+# Get config files
+config_files=(${source_dir}/config.*(N))  # (N) = Nullglob
+
+if (( ${#config_files[@]} == 0 )); then
+  echo "No config files found in $source_dir"
+  exit 1
+fi
+
+# Build colon-separated list
+kubeconfig=$(IFS=:; echo "${config_files[*]}")
+echo "Merging kubeconfigs: $kubeconfig"
+
+# Merge and write output
+KUBECONFIG="$kubeconfig" kubectl config view --flatten > "$output_file"
+chmod 600 "$output_file"
+echo "Merged kubeconfig written to $output_file"


### PR DESCRIPTION
This pull request enhances the `omz` configuration by adding support for custom scripts and includes a new utility script for managing Kubernetes configurations. The most important changes focus on improving script organization and functionality.

### Enhancements to `omz` configuration:

* [`omz/configure.sh`](diffhunk://#diff-48b44c789eda4a99e8d47330ea4712cf7031dc3be75246f54c070558330be758R50-R62): Added logic to set up custom scripts by creating symlinks for all scripts in the `omz/scripts` directory to the user's `~/bin` directory. This includes removing dead symlinks and ensuring the `~/bin` directory exists.

### New utility script:

* [`omz/scripts/merge_kube_configs.zsh`](diffhunk://#diff-3e800710d66d0fc8d0585ac061e5635c9e5786a42a7cb6e983e9ea1cf27ac38aR1-R31): Introduced a script to merge multiple Kubernetes configuration files from `~/.kube/configs` into a single output file at `~/.kube/config`. The script ensures the source directory exists, handles cases with no config files, and sets appropriate file permissions for the output.