### PR TITLE
Add cooldown and pre-commit config to CI automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,11 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci(actions)"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 10
+    commit-message:
+      prefix: "ci(hooks)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    cooldown:
+      default-days: 10
     commit-message:
       prefix: "ci(actions)"
   - package-ecosystem: "pre-commit"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_install_hook_types:
   - commit-msg
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 9f3ec868c0429155a46b4819b625d47a8522a3d5  # frozen: v4.10.0
+    rev: 4fbeae7861663ecf4b4989211eba41c1a3fb1227  # frozen: v4.13.9
     hooks:
       - id: commitizen
         stages:


### PR DESCRIPTION
Introduces cooldown periods for GitHub Actions and pre-commit updates, and bumps commitizen to v4.13.9 for improved commit workflow automation.

# Changes

## CI
- dependabot: add cooldown to GitHub Actions configuration to reduce update frequency
- dependabot: add pre-commit configuration for monthly update checks with cooldown
- hooks: bump commitizen-tools/commitizen from v4.10.0 to v4.13.9 for pre-commit
