### PR TITLE
Improve gcfuh completion, clarify ccm prompt, add VS Code theme settings

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 3.3.0
+  version: 3.4.0
   version_scheme: semver

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#3399ff",
+        "activityBar.background": "#3399ff",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#bf0060",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#3399ff",
+        "statusBar.background": "#007fff",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#3399ff",
+        "statusBarItem.remoteBackground": "#007fff",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#007fff",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#007fff99",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#007fff"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v3.4.0 (2026-05-07)
+
+### Feature
+
+- **omz**: improve gcfuh completion to suggest changed files instead of commits
+
+### Fix
+
+- **omz**: clarify commit skill requirements in ccm prompt
+
 ## v3.3.0 (2026-04-12)
 
 ### Feature

--- a/omz/completions/_gcfuh
+++ b/omz/completions/_gcfuh
@@ -1,11 +1,33 @@
 #compdef gcfuh
 
 # Completion for the "gcfuh" (git commit fixup helper) command.
-# Uses _commits_since_merge for commit hash completion.
+# Completes files with uncommitted changes.
+function _gcfuh_changed_files() {
+  if git rev-parse --git-dir >/dev/null 2>&1; then
+    local -a files
+    local line path
+
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      path="${line:3}"
+
+      # For renames, complete the destination path.
+      if [[ "$path" == *" -> "* ]]; then
+        path="${path##* -> }"
+      fi
+
+      files+=("$path")
+    done <<< "$(git status --short 2>/dev/null)"
+
+    typeset -U files
+    [[ ${#files[@]} -gt 0 ]] && _describe -t files 'changed files' files
+  fi
+}
+
 function _gcfuh() {
   _arguments -s -S \
     '(-h --help)'{-h,--help}'[Show help message]' \
-    '1::commit:_commits_since_merge'
+    '*:file:_gcfuh_changed_files'
 }
 
 _gcfuh "$@"

--- a/omz/functions/ccm
+++ b/omz/functions/ccm
@@ -145,7 +145,7 @@ if ! context="$(
 fi
 
 prompt=$(cat <<EOF
-Use the conventional-commit skill.
+You **MUST** use the conventional-commit skill.
 
 Create a Conventional Commit message for the staged Git context below.
 
@@ -161,6 +161,8 @@ Output requirements:
 - No explanations
 - Keep the subject under 72 characters
 - Use imperative mood
+- NEVER use 'chore' as a commit type
+- do not use multiple scopes in a single commit
 
 $context
 EOF


### PR DESCRIPTION
Enhances the gcfuh completion to suggest changed files, clarifies ccm prompt skill requirements, and adds custom VS Code color theme settings.

# Changes

## Feature
- omz: improve gcfuh completion to suggest changed files instead of commits

## Fix
- omz: clarify commit skill requirements in ccm prompt
  - Emphasize using the conventional-commit skill, prohibit 'chore' type, and disallow multiple scopes in a single commit

## Build
- vscode: add custom color theme settings for activity and status bars
  - Adds .vscode/settings.json with color customizations for VS Code UI elements