### PR TITLE
Improve OMZ commit helper completions and ccm default model

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 3.4.0
+  version: 3.4.1
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v3.4.1 (2026-06-14)
+
+### Fix
+
+- **omz**: include staged changes in gcfuh completion
+- **omz**: preserve commit subjects in fixup completion
+- **omz**: replace deprecated gpt 4.1 model with 5.4-mini in ccm function
+
 ## v3.4.0 (2026-05-07)
 
 ### Feature

--- a/omz/completions/_commits_since_merge
+++ b/omz/completions/_commits_since_merge
@@ -6,18 +6,25 @@ function _commits_since_merge() {
   if git rev-parse --git-dir >/dev/null 2>&1; then
     local -a commits
     local merge_base
+    local log_output
+    local line
 
     # Find where current branch diverged from main branch
     merge_base=$(git_find_branch_base)
 
     # If merge base found, show commits since then; otherwise show recent commits
     if [[ -n "$merge_base" ]]; then
-      commits=(${(f)"$(git log --oneline --no-decorate "$merge_base"..HEAD 2>/dev/null | awk '{print $1":"substr($0, index($0,$2))}')"})
+      log_output=$(git log --oneline --no-decorate --grep='^fixup! ' --invert-grep "$merge_base"..HEAD 2>/dev/null)
     else
-      commits=(${(f)"$(git log --oneline --no-decorate -n 25 2>/dev/null | awk '{print $1":"substr($0, index($0,$2))}')"})
+      log_output=$(git log --oneline --no-decorate --grep='^fixup! ' --invert-grep -n 25 2>/dev/null)
     fi
 
-    [[ ${#commits[@]} -gt 0 ]] && _describe -t commits 'commits' commits
+    commits=()
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && commits+=("$line")
+    done < <(printf '%s\n' "$log_output" | awk '{print $1":"substr($0, index($0,$2))}')
+
+    [[ ${#commits[@]} -gt 0 ]] && _describe -V -t commits 'commits' commits
   fi
 }
 

--- a/omz/completions/_gcfuh
+++ b/omz/completions/_gcfuh
@@ -1,26 +1,31 @@
 #compdef gcfuh
 
 # Completion for the "gcfuh" (git commit fixup helper) command.
-# Completes files with uncommitted changes.
+# Completes files with staged or unstaged changes.
 function _gcfuh_changed_files() {
   if git rev-parse --git-dir >/dev/null 2>&1; then
     local -a files
-    local line path
+    local line changed_file
 
     while IFS= read -r line; do
       [[ -z "$line" ]] && continue
-      path="${line:3}"
+      changed_file="${line:3}"
 
       # For renames, complete the destination path.
-      if [[ "$path" == *" -> "* ]]; then
-        path="${path##* -> }"
+      if [[ "$changed_file" == *" -> "* ]]; then
+        changed_file="${changed_file##* -> }"
       fi
 
-      files+=("$path")
-    done <<< "$(git status --short 2>/dev/null)"
+      files+=("$changed_file")
+    done <<< "$(git status --short --untracked-files=all 2>/dev/null)"
 
     typeset -U files
-    [[ ${#files[@]} -gt 0 ]] && _describe -t files 'changed files' files
+    if [[ ${#files[@]} -eq 0 ]]; then
+      _message 'no staged or unstaged changes'
+      return 1
+    fi
+
+    _describe -V -t files 'changed files' files
   fi
 }
 

--- a/omz/functions/ccm
+++ b/omz/functions/ccm
@@ -3,7 +3,7 @@
 #######################################
 setopt localoptions localtraps
 
-local model="gpt-4.1"
+local model="gpt-5.4-mini"
 local reasoning_effort=""
 local show_help=0
 
@@ -77,7 +77,7 @@ Generate a Conventional Commit message from the currently staged changes using C
 then open git commit with the generated message.
 
 Options:
-  -m, --model <MODEL>                      Model to use for generation. Default: gpt-4.1
+  -m, --model <MODEL>                      Model to use for generation. Default: gpt-5.4-mini
   -r, --reasoning-effort <EFFORT>         Optional reasoning effort for supported models.
   -h, --help                              Show this help
 


### PR DESCRIPTION
# Changes

## Fix
- omz: improve `gcfuh` completion to include staged, unstaged, and untracked files, handle renames, and show a clear empty-state message
- omz: preserve full commit subjects & order in fixup completion and hide existing `fixup!` commits from the candidate list
- omz: switch `ccm` default model and help text from `gpt-4.1` to `gpt-5.4-mini`