### PR TITLE
Harden gcfuh, fix grias, and add autosquash + blame-based target suggestion

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 3.4.1
+  version: 3.5.0
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v3.5.0 (2026-06-21)
+
+### Feature
+
+- **omz**: suggest gcfuh fixup target via git blame
+- **omz**: offer autosquash rebase after gcfuh creates fixups
+
+### Fix
+
+- **omz**: use grias target argument as rebase base
+- **omz**: harden gcfuh fixup helper
+
 ## v3.4.1 (2026-06-14)
 
 ### Fix

--- a/omz/functions.zsh
+++ b/omz/functions.zsh
@@ -177,10 +177,10 @@ function gciaf() {
 #######################################
 function grias() {
   local target=$1
+  local base_branch=$target
 
   # If no argument, find the base branch
-  if [[ -z $target ]]; then
-    local base_branch
+  if [[ -z $base_branch ]]; then
     base_branch=$(git_find_branch_base -n)
     [[ -z $base_branch ]] && { echo "grias: could not find main/master/develop/development/production" >&2; return 1; }
   fi

--- a/omz/functions.zsh
+++ b/omz/functions.zsh
@@ -189,6 +189,92 @@ function grias() {
 }
 
 #######################################
+# _gcfuh_blame_target - suggest a fixup target by blaming changed lines
+#
+# Blames the lines a file's unstaged changes actually touch (the old side of
+# each diff hunk) against HEAD, and returns the newest on-branch commit among
+# the results. This is more precise than "the file's last commit" when a file
+# spans several branch commits. Pure additions and new/untracked files yield
+# nothing (there are no committed lines to blame).
+#
+# Usage:
+#   suggestion=$(_gcfuh_blame_target path/to/file "$merge_boundary")
+#
+# Arguments:
+#   $1  File path (must exist in HEAD)
+#   $2  Merge boundary commit (output of git_find_branch_base)
+# Returns:
+#   "<short-hash> <subject>" of the suggested commit, or empty string
+#######################################
+function _gcfuh_blame_target() {
+  emulate -L zsh
+  local file=$1 merge_boundary=$2
+  [[ -n "$file" && -n "$merge_boundary" ]] || return 0
+
+  # Only tracked files have committed lines to blame
+  git cat-file -e "HEAD:$file" 2>/dev/null || return 0
+
+  # Map on-branch commit full-hash -> order index (0 = newest), excluding
+  # autosquash commits, so we can both filter and rank blame results.
+  local -A on_branch_idx=()
+  local idx=0 full_hash
+  while IFS= read -r full_hash; do
+    [[ -n "$full_hash" ]] && on_branch_idx[$full_hash]=$idx && idx=$((idx + 1))
+  done < <(git log --format='%H' --grep='^fixup! ' --grep='^squash! ' --grep='^amend! ' --invert-grep "${merge_boundary}..HEAD" 2>/dev/null)
+  [[ ${#on_branch_idx[@]} -eq 0 ]] && return 0
+
+  # Walk the diff and record the HEAD line numbers that are actually removed or
+  # modified (lines starting with '-'), tracking the old-side line counter.
+  # Context and added lines are skipped so we never blame unrelated lines.
+  local -a removed=()
+  local line hunk in_hunk=0 old_lineno=0
+  while IFS= read -r line; do
+    if [[ "$line" == @@* ]]; then
+      hunk="${line#@@ -}"; hunk="${hunk%% +*}"   # "oldStart[,oldCount]"
+      old_lineno="${hunk%%,*}"
+      in_hunk=1
+      continue
+    fi
+    (( in_hunk )) || continue
+    case "$line" in
+      '\'*) ;;                                       # "\ No newline at end of file"
+      +*) ;;                                         # added line: no old counterpart
+      -*) removed+=($old_lineno); old_lineno=$((old_lineno + 1)) ;;
+      *)  old_lineno=$((old_lineno + 1)) ;;          # context line
+    esac
+  done < <(git diff --no-ext-diff -- "$file" 2>/dev/null)
+  [[ ${#removed[@]} -eq 0 ]] && return 0             # pure additions: nothing to blame
+
+  # Group the removed line numbers (already ascending) into contiguous ranges
+  local -a ranges=()
+  local ln run_start=-1 run_prev=-1
+  for ln in "${removed[@]}"; do
+    if (( run_start < 0 )); then run_start=$ln; run_prev=$ln
+    elif (( ln == run_prev + 1 )); then run_prev=$ln
+    else ranges+=("${run_start},${run_prev}"); run_start=$ln; run_prev=$ln
+    fi
+  done
+  (( run_start >= 0 )) && ranges+=("${run_start},${run_prev}")
+
+  # Blame each range in HEAD; keep the newest on-branch commit touched.
+  local best_idx=-1 best_hash="" r bline
+  for r in "${ranges[@]}"; do
+    while IFS= read -r bline; do
+      [[ "$bline" =~ '^([0-9a-f]{40}) ' ]] || continue
+      full_hash=$match[1]
+      [[ -n "${on_branch_idx[$full_hash]}" ]] || continue
+      if (( best_idx < 0 || on_branch_idx[$full_hash] < best_idx )); then
+        best_idx=$on_branch_idx[$full_hash]
+        best_hash=$full_hash
+      fi
+    done < <(git blame -L "$r" --porcelain HEAD -- "$file" 2>/dev/null)
+  done
+
+  [[ -n "$best_hash" ]] && git log -1 --format='%h %s' "$best_hash" 2>/dev/null
+  return 0
+}
+
+#######################################
 # git_find_branch_base - Find base branch name or merge base commit
 #
 # Searches for main/master/develop/development/production branches.

--- a/omz/functions/gcfuh
+++ b/omz/functions/gcfuh
@@ -23,7 +23,7 @@ With file arguments it provides per-file commit selection:
   - Files with no on-branch history can be assigned to any on-branch commit
   - Files are grouped by selected target and one fixup commit is created per target
 
-The function automatically unstages all files at start to prevent accidental inclusion. In no-args mode, it loops back if there are remaining changes.
+Once it confirms there are commits to fixup, the function unstages all files to prevent accidental inclusion (your index is left untouched if there is nothing to do). Staged renames are re-paired so both the old and new path land in the same fixup. In no-args mode, it loops back if there are remaining changes.
 
 Keybindings in fzf:
   No-args mode, file selection:
@@ -42,11 +42,18 @@ EOF
   return 0
 fi
 
-# Use clean zsh emulation and disable debug output
-setopt TYPESET_SILENT 2>/dev/null
+# Reset to zsh defaults locally so option changes don't leak into the shell
+emulate -L zsh
+setopt typeset_silent
 
 # Ensure we're in a git repository
 _fzf_git_check || return 1
+
+# This helper is fzf-driven; fail clearly if fzf is unavailable
+if ! command -v fzf >/dev/null 2>&1; then
+  pprint "gcfuh requires fzf, which was not found in PATH." "$fgYellow"
+  return 1
+fi
 
 # Separator for section headers (using box-drawing characters)
 local SEP='─────────'
@@ -57,27 +64,17 @@ local YELLOW=$'\033[33m'
 local GREEN=$'\033[32m'
 local BLUE=$'\033[34m'
 
-# Unstage all files to start fresh
-git restore --staged . 2>/dev/null
-
 # Find where current branch diverged from main branch
 local merge_boundary
 merge_boundary=$(git_find_branch_base)
 
-# Build list of ALL on-branch commits (not just those with current changes)
-# Exclude fixup commits (no fixup of fixup)
+# Build list of ALL on-branch commits (not just those with current changes).
+# Exclude autosquash commits (fixup!/squash!/amend!) so we never fixup a fixup.
 local -a unique_commits=()
-local all_commits commit_line
-all_commits=$(git log --format='%h %s' "${merge_boundary}..HEAD" 2>/dev/null)
-
+local commit_line
 while IFS= read -r commit_line; do
-  [[ -z "$commit_line" ]] && continue
-  # Skip fixup commits (subject starts with "fixup!")
-  if [[ "$commit_line" =~ ^[a-f0-9]+\ fixup! ]]; then
-    continue
-  fi
-  unique_commits+=("$commit_line")
-done <<< "$all_commits"
+  [[ -n "$commit_line" ]] && unique_commits+=("$commit_line")
+done < <(git log --format='%h %s' --grep='^fixup! ' --grep='^squash! ' --grep='^amend! ' --invert-grep "${merge_boundary}..HEAD" 2>/dev/null)
 
 # If no on-branch commits to fixup, inform user
 if [[ ${#unique_commits[@]} -eq 0 ]]; then
@@ -85,14 +82,31 @@ if [[ ${#unique_commits[@]} -eq 0 ]]; then
   return 0
 fi
 
+# Capture staged renames BEFORE unstaging. "git restore --staged" splits a
+# rename into a delete + untracked pair and loses the pairing, which would
+# leave the old-path deletion out of the fixup. Map destination -> source so
+# we can re-pair them: classify the destination by the source's history and
+# stage both paths together.
+local -A rename_map=()      # dest path -> source path
+local -A rename_src_set=()  # source path -> 1 (delete half to hide from lists)
+local _entry _rest _i
+while IFS= read -r _entry; do
+  [[ "$_entry" == 2\ * ]] || continue   # porcelain v2 type-2 = rename/copy
+  _rest="$_entry"
+  for _i in {1..9}; do _rest="${_rest#* }"; done  # strip 9 header fields
+  rename_map[${_rest%%$'\t'*}]="${_rest##*$'\t'}" # _rest is "dest<TAB>source"
+  rename_src_set[${_rest##*$'\t'}]=1
+done < <(git status --porcelain=v2 2>/dev/null)
+
+# Unstage everything to start fresh (now that we know there is work to do)
+git restore --staged . 2>/dev/null
+
 # ─── Files-passed mode ──────────────────────────────────────────────
 if [[ $# -gt 0 ]]; then
   local -a passed_files=("$@")
 
   # Validate passed files: must have uncommitted changes according to git status
   local -a valid_files=()
-  local status_output
-  status_output=$(git status -s 2>/dev/null)
   for file in "${passed_files[@]}"; do
     if git status -s -- "$file" | grep -q .; then
       valid_files+=("$file")
@@ -112,18 +126,16 @@ if [[ $# -gt 0 ]]; then
   local -a fixup_order=()       # ordered unique target hashes
 
   for file in "${valid_files[@]}"; do
-    # Find on-branch commits that touched this file (excluding fixup commits)
-    local -a file_candidates=()
-    local file_commits_output candidate_line
-    file_commits_output=$(git log --format='%h %s' "${merge_boundary}..HEAD" -- "$file" 2>/dev/null)
+    # For a renamed destination, history lives under the source path
+    local hist_path="$file"
+    [[ -n "${rename_map[$file]}" ]] && hist_path="${rename_map[$file]}"
 
+    # Find on-branch commits that touched this file (excluding autosquash commits)
+    local -a file_candidates=()
+    local candidate_line
     while IFS= read -r candidate_line; do
-      [[ -z "$candidate_line" ]] && continue
-      if [[ "$candidate_line" =~ ^[a-f0-9]+\ fixup! ]]; then
-        continue
-      fi
-      file_candidates+=("$candidate_line")
-    done <<< "$file_commits_output"
+      [[ -n "$candidate_line" ]] && file_candidates+=("$candidate_line")
+    done < <(git log --format='%h %s' --grep='^fixup! ' --grep='^squash! ' --grep='^amend! ' --invert-grep "${merge_boundary}..HEAD" -- "$hist_path" 2>/dev/null)
 
     # Fallback: if no on-branch commits touched this file, offer all on-branch commits
     if [[ ${#file_candidates[@]} -eq 0 ]]; then
@@ -187,14 +199,20 @@ if [[ $# -gt 0 ]]; then
   printf '%b' "${fgYellow}Proceed? [y/N]:${txReset} "
   read -r response
 
-  if [[ "$response" =~ ^[Yy]$ ]]; then
+  if [[ "$response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
     for target_hash in "${fixup_order[@]}"; do
       local -a group_files=()
       while IFS= read -r file; do
         group_files+=("$file")
+        # Also stage the deletion half of a rename so the fixup is complete
+        [[ -n "${rename_map[$file]}" ]] && group_files+=("${rename_map[$file]}")
       done <<< "${fixup_file_map[$target_hash]}"
 
-      git add "${group_files[@]}"
+      if ! git add "${group_files[@]}"; then
+        echo
+        pprint "✗ Failed to stage files for ${target_hash}" "$fgRed"
+        return 1
+      fi
       if git commit --fixup "$target_hash"; then
         echo
         pprint "✓ Fixup commit created for ${target_hash}" "$fgGreen"
@@ -239,15 +257,22 @@ while true; do
       file="${file##* -> }"
     fi
 
+    # Skip the delete half of a staged rename; it is handled via its destination
+    [[ -n "${rename_src_set[$file]}" ]] && continue
+
+    # For a renamed destination, history lives under the source path
+    local hist_path="$file"
+    [[ -n "${rename_map[$file]}" ]] && hist_path="${rename_map[$file]}"
+
     # Get the last commit for this file
-    file_last_commit=$(git log -1 --format='%H' -- "$file" 2>/dev/null)
+    file_last_commit=$(git log -1 --format='%H' -- "$hist_path" 2>/dev/null)
 
     if [[ -z "$file_last_commit" ]]; then
       # New file - no commit history
       new_files+=("$file")
-    elif [[ -n "$merge_boundary" ]] && git merge-base --is-ancestor "$merge_boundary" "$file_last_commit" 2>/dev/null; then
+    elif [[ -n "$merge_boundary" && "$file_last_commit" != "$merge_boundary" ]] && git merge-base --is-ancestor "$merge_boundary" "$file_last_commit" 2>/dev/null; then
       # File's last commit is after the merge boundary - on current branch
-      commit_info=$(git log -1 --format='%h %s' -- "$file" 2>/dev/null)
+      commit_info=$(git log -1 --format='%h %s' -- "$hist_path" 2>/dev/null)
       short_hash="${commit_info%% *}"
       file_commits[$file]="$commit_info"
       on_branch_files+=("$file")
@@ -334,7 +359,7 @@ while true; do
       --border-label "📁 Select Files for ${target_hash} ${target_subject}" \
       --header $'Select files to include in fixup\nTAB (toggle) ╱ CTRL-A (all) ╱ CTRL-D (none)\n' \
       --bind 'ctrl-a:select-all,ctrl-d:deselect-all' \
-      --preview "f=\$(echo {} | sed 's/^  //'); [[ -f \"\$f\" ]] && git diff --no-ext-diff --color=always -- \"\$f\" 2>/dev/null | head -100 || echo 'Section header'"
+      --preview "line={}; if [[ \$line == *${SEP}* ]]; then echo 'Section header'; else f=\${line##  }; git diff --no-ext-diff --color=always -- \"\$f\" 2>/dev/null | head -100; fi"
   )
 
   # Exit silently if user cancelled
@@ -375,9 +400,17 @@ while true; do
   printf '%b' "${fgYellow}Proceed? [y/N]:${txReset} "
   read -r response
 
-  if [[ "$response" =~ ^[Yy]$ ]]; then
-    # Execute the fixup
-    git add "${files_to_add[@]}"
+  if [[ "$response" =~ ^[Yy]([Ee][Ss])?$ ]]; then
+    # Execute the fixup, also staging the deletion half of any rename
+    local -a add_paths=("${files_to_add[@]}")
+    for f in "${files_to_add[@]}"; do
+      [[ -n "${rename_map[$f]}" ]] && add_paths+=("${rename_map[$f]}")
+    done
+    if ! git add "${add_paths[@]}"; then
+      echo
+      pprint "✗ Failed to stage files" "$fgRed"
+      return 1
+    fi
     if git commit --fixup "$target_hash"; then
       echo
       pprint "✓ Fixup commit created" "$fgGreen"

--- a/omz/functions/gcfuh
+++ b/omz/functions/gcfuh
@@ -15,11 +15,14 @@ This function helps you organize uncommitted changes into fixup commits for prev
 
 Without arguments it provides a two-stage interactive selection:
   1. Select a target commit to fixup (from commits after the most recent merge)
-  2. Select files to include in the fixup (grouped by their last commit)
+  2. Select files to include in the fixup (grouped by the commit that last
+     touched their changed lines, via git blame)
 
 With file arguments it provides per-file commit selection:
   - Each file is matched to the on-branch commits that touched it
   - If only one commit touched the file, it is auto-selected
+  - Otherwise the commit that last touched the changed lines (determined by
+    git blame) is suggested as the default (top) entry in the picker
   - Files with no on-branch history can be assigned to any on-branch commit
   - Files are grouped by selected target and one fixup commit is created per target
 
@@ -155,16 +158,36 @@ if [[ $# -gt 0 ]]; then
       target_subject="${file_candidates[1]#* }"
       pprint "Auto-selected ${target_hash}: ${target_subject} for ${file}" "$fgGreen"
     else
-      # Prompt user to select a commit for this file
+      # Suggest a target by blaming the changed lines, and float it to the top
+      # of the list (fzf highlights the first row by default). Skip for renames.
+      local blame_hash="" candidate
+      if [[ "$hist_path" == "$file" ]]; then
+        blame_hash=$(_gcfuh_blame_target "$file" "$merge_boundary")
+        blame_hash="${blame_hash%% *}"
+      fi
+      if [[ -n "$blame_hash" ]]; then
+        local -a ordered=()
+        for candidate in "${file_candidates[@]}"; do
+          [[ "${candidate%% *}" == "$blame_hash" ]] && ordered=("$candidate")
+        done
+        for candidate in "${file_candidates[@]}"; do
+          [[ "${candidate%% *}" != "$blame_hash" ]] && ordered+=("$candidate")
+        done
+        [[ ${#ordered[@]} -eq ${#file_candidates[@]} ]] && file_candidates=("${ordered[@]}")
+      fi
+
+      # Prompt user to select a commit for this file. Preview the file under
+      # its history path (the source path for renames) so candidates that
+      # predate a rename still render a useful diff.
       local escaped_file
-      escaped_file=$(printf '%q' "$file")
+      escaped_file=$(printf '%q' "$hist_path")
       local selected
       selected=$(
         for candidate in "${file_candidates[@]}"; do
           echo "$candidate"
         done | _fzf_git_fzf --no-multi --ansi \
           --border-label "🔧 Select Fixup Target for ${file}" \
-          --header $'Select which commit to fixup for this file\nCTRL-/ (toggle preview)\n' \
+          --header $'Select which commit to fixup for this file (top = suggested)\nCTRL-/ (toggle preview)\n' \
           --preview "hash=\$(echo {} | cut -d' ' -f1); git show --color=always \$hash -- ${escaped_file} 2>/dev/null | head -120"
       )
 
@@ -286,8 +309,13 @@ while true; do
       # New file - no commit history
       new_files+=("$file")
     elif [[ -n "$merge_boundary" && "$file_last_commit" != "$merge_boundary" ]] && git merge-base --is-ancestor "$merge_boundary" "$file_last_commit" 2>/dev/null; then
-      # File's last commit is after the merge boundary - on current branch
-      commit_info=$(git log -1 --format='%h %s' -- "$hist_path" 2>/dev/null)
+      # File's last commit is after the merge boundary - on current branch.
+      # Prefer the commit that last touched the changed lines (blame-based);
+      # fall back to the file's last commit. Skip blame for renames, whose
+      # working-tree changes live under a different path than their history.
+      commit_info=""
+      [[ "$hist_path" == "$file" ]] && commit_info=$(_gcfuh_blame_target "$file" "$merge_boundary")
+      [[ -z "$commit_info" ]] && commit_info=$(git log -1 --format='%h %s' -- "$hist_path" 2>/dev/null)
       short_hash="${commit_info%% *}"
       file_commits[$file]="$commit_info"
       on_branch_files+=("$file")

--- a/omz/functions/gcfuh
+++ b/omz/functions/gcfuh
@@ -25,6 +25,8 @@ With file arguments it provides per-file commit selection:
 
 Once it confirms there are commits to fixup, the function unstages all files to prevent accidental inclusion (your index is left untouched if there is nothing to do). Staged renames are re-paired so both the old and new path land in the same fixup. In no-args mode, it loops back if there are remaining changes.
 
+After creating one or more fixups, it offers to run an autosquash rebase (git rebase -i --autosquash) so you can squash them into their targets immediately.
+
 Keybindings in fzf:
   No-args mode, file selection:
     TAB       Toggle selection
@@ -100,6 +102,9 @@ done < <(git status --porcelain=v2 2>/dev/null)
 
 # Unstage everything to start fresh (now that we know there is work to do)
 git restore --staged . 2>/dev/null
+
+# Track how many fixups we create so we can offer an autosquash rebase at the end
+local fixups_created=0
 
 # ─── Files-passed mode ──────────────────────────────────────────────
 if [[ $# -gt 0 ]]; then
@@ -216,6 +221,7 @@ if [[ $# -gt 0 ]]; then
       if git commit --fixup "$target_hash"; then
         echo
         pprint "✓ Fixup commit created for ${target_hash}" "$fgGreen"
+        fixups_created=$((fixups_created + 1))
       else
         echo
         pprint "✗ Fixup commit failed for ${target_hash}" "$fgRed"
@@ -224,6 +230,15 @@ if [[ $# -gt 0 ]]; then
     done
   else
     pprint "Aborted." "$fgYellow"
+  fi
+
+  # Offer to autosquash the new fixups right away (reuses grias)
+  if [[ $fixups_created -gt 0 ]]; then
+    echo
+    local do_rebase
+    printf '%b' "${fgYellow}Run autosquash rebase now? [y/N]:${txReset} "
+    read -r do_rebase
+    [[ "$do_rebase" =~ ^[Yy]([Ee][Ss])?$ ]] && grias
   fi
 
   return 0
@@ -237,7 +252,7 @@ while true; do
   changes=$(git status -s 2>/dev/null)
   if [[ -z "$changes" ]]; then
     pprint "No uncommitted changes found." "$fgYellow"
-    return 0
+    break
   fi
 
   # Build arrays for file categorization
@@ -294,8 +309,8 @@ while true; do
       --preview 'hash=$(echo {} | cut -d" " -f1); git show --color=always --stat $hash | head -50'
   )
 
-  # Exit silently if user cancelled
-  [[ -z "$target_commit" ]] && return 0
+  # Stop the loop if user cancelled
+  [[ -z "$target_commit" ]] && break
 
   target_hash="${target_commit%% *}"
   target_subject="${target_commit#* }"
@@ -362,8 +377,8 @@ while true; do
       --preview "line={}; if [[ \$line == *${SEP}* ]]; then echo 'Section header'; else f=\${line##  }; git diff --no-ext-diff --color=always -- \"\$f\" 2>/dev/null | head -100; fi"
   )
 
-  # Exit silently if user cancelled
-  [[ -z "$selected_files" ]] && return 0
+  # Stop the loop if user cancelled
+  [[ -z "$selected_files" ]] && break
 
   # Filter out section headers and clean up file paths
   local -a files_to_add=()
@@ -414,6 +429,7 @@ while true; do
     if git commit --fixup "$target_hash"; then
       echo
       pprint "✓ Fixup commit created" "$fgGreen"
+      fixups_created=$((fixups_created + 1))
     else
       echo
       pprint "✗ Fixup commit failed" "$fgRed"
@@ -425,3 +441,12 @@ while true; do
 
   echo
 done
+
+# Offer to autosquash the new fixups right away (reuses grias)
+if [[ $fixups_created -gt 0 ]]; then
+  echo
+  local do_rebase
+  printf '%b' "${fgYellow}Run autosquash rebase now? [y/N]:${txReset} "
+  read -r do_rebase
+  [[ "$do_rebase" =~ ^[Yy]([Ee][Ss])?$ ]] && grias
+fi


### PR DESCRIPTION
## Summary
Reviews and improves the `gcfuh` (git commit fixup helper) workflow: fixes a set
of correctness/robustness bugs, repairs a latent `grias` bug, and adds two
quality-of-life features. Each change is its own commit.

## Changes

### `fix(omz): harden gcfuh fixup helper`
- **Preserve the index when there's nothing to do** - only unstage after confirming there are commits to fixup, so running `gcfuh` in a repo with no on-branch commits no longer blows away a carefully staged index.
- **Renames are no longer half-committed** — `git restore --staged` splits a staged rename into a delete + untracked pair; renames are now captured up front (porcelain v2) and re-paired so both paths land in the same fixup.
- **Exclude `squash!`/`amend!` commits** from fixup targets (not just `fixup!`), via `git log --grep … --invert-grep`, consistent with `_commits_since_merge`.
- **Abort if `git add` fails** instead of creating a partial/empty fixup.
- **Exclude the merge-base commit itself** from on-branch classification.
- **Correct preview for deleted files** (was showing "Section header").
- Accept `yes` as well as `y` at confirmation prompts.
- Scope shell options with `emulate -L zsh` (no more leaking into the user's shell), require `fzf` up front, and drop a dead variable.

### `fix(omz): use grias target argument as rebase base`
When a ref was passed to `grias`, `base_branch` was never assigned, so the autosquash rebase ran with an empty ref. It now defaults to the supplied target.

### `feat(omz): offer autosquash rebase after gcfuh creates fixups`
After creating one or more fixups (either mode), `gcfuh` offers to run an autosquash rebase immediately, reusing `grias`.

### `feat(omz): suggest gcfuh fixup target via git blame`
New `_gcfuh_blame_target` helper blames the lines a file's changes actually touch and returns the newest on-branch commit among them. `gcfuh` uses it to group files (no-args mode) and to surface a suggested default in the per-file
picker (files mode), falling back to the file's last commit. Renames, new files, and pure additions fall back to prior behavior.