### PR TITLE
omz: add czbnt to bump without leaving a tag

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 3.5.0
+  version: 3.6.0
   version_scheme: semver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v3.6.0 (2026-06-21)
+
+### Feature
+
+- **omz**: add czbnt to bump without leaving a tag
+
 ## v3.5.0 (2026-06-21)
 
 ### Feature

--- a/omz/README.md
+++ b/omz/README.md
@@ -40,6 +40,7 @@ Individual function files that are autoloaded on-demand. Each file contains a si
 - **`decode_cert`** - Decode SSL/TLS certificates
 - **`decode_jwt`** - Decode JWT tokens
 - **`get_k8s_images`** - Extract container images from Kubernetes pods with filtering and parsing options
+- **`git_delete_head_semver_tags`** - Delete local semver tags pointing at HEAD (e.g. the one `cz bump` creates)
 - **`git_pr_check`** - Check subdirectories for GitHub pull requests
 - **`git_tag_semver`** - Semantically tag a git repository with major/minor/patch versions
 - **`install_it`** - Use Linux `install` to install binaries in `/usr/local/bin`
@@ -53,8 +54,10 @@ Individual function files that are autoloaded on-demand. Each file contains a si
 
 Zsh completion functions (prefixed with `_`) symlinked to `$ZSH_CUSTOM/completions/`:
 
+- **`_czbnt`** - Completion for czbnt function
 - **`_decode_cert`** - Completion for decode_cert function
 - **`_decode_jwt`** - Completion for decode_jwt function
+- **`_git_delete_head_semver_tags`** - Completion for git_delete_head_semver_tags function
 - **`_fzf`** - FZF completion
 - **`_getRelease`** - Completion for getRelease CLI
 - **`_install_it`** - Completion for install_it function

--- a/omz/completions/_czbnt
+++ b/omz/completions/_czbnt
@@ -1,0 +1,12 @@
+#compdef czbnt
+
+# Completion for "czbnt" (cz bump, then strip the tag it created).
+# Offers the most common `cz bump` flags; see `cz bump --help` for the full set.
+function _czbnt() {
+  _arguments -s \
+    '--increment[Manually specify the increment]:increment:(MAJOR MINOR PATCH)' \
+    '--prerelease[Choose a prerelease phase]:phase:(alpha beta rc)' \
+    '--changelog[Generate the changelog for the newest version]' \
+    '--dry-run[Show the bump without applying it]' \
+    '--yes[Answer yes to all prompts]'
+}

--- a/omz/completions/_git_delete_head_semver_tags
+++ b/omz/completions/_git_delete_head_semver_tags
@@ -1,0 +1,7 @@
+#compdef git_delete_head_semver_tags
+
+# Completion for the "git_delete_head_semver_tags" command.
+function _git_delete_head_semver_tags() {
+  _arguments -s -S \
+    '(- *)'{-h,--help}'[Show help message]'
+}

--- a/omz/functions.zsh
+++ b/omz/functions.zsh
@@ -189,6 +189,17 @@ function grias() {
 }
 
 #######################################
+# czbnt - commitizen bump, then strip the tag it created
+# Arguments:
+#   Any arguments accepted by `cz bump` (e.g. --increment PATCH)
+# Outputs:
+#   Runs `cz bump`, then deletes the semver tag it left on HEAD
+#######################################
+function czbnt() {
+  cz bump "$@" && git_delete_head_semver_tags
+}
+
+#######################################
 # _gcfuh_blame_target - suggest a fixup target by blaming changed lines
 #
 # Blames the lines a file's unstaged changes actually touch (the old side of

--- a/omz/functions/git_delete_head_semver_tags
+++ b/omz/functions/git_delete_head_semver_tags
@@ -1,0 +1,33 @@
+#######################################
+# git_delete_head_semver_tags
+#######################################
+if [[ $1 == "--help" || $1 == "-h" ]]; then
+  fold -w "$(tput cols)" -s <<'EOF'
+Usage: git_delete_head_semver_tags
+Delete any local semver tags (vX.Y.Z or X.Y.Z) that point at HEAD.
+
+Intended to strip the tag that `cz bump` creates on its bump commit, so the
+commit can be rebased/squashed freely and tagged later (see git_tag_semver).
+EOF
+  return 0
+fi
+
+if ! git rev-parse --git-dir &>/dev/null; then
+  echo "Not a git repository" >&2
+  return 1
+fi
+
+local -a tags
+tags=("${(@f)$(git tag --points-at HEAD | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$')}")
+tags=("${(@)tags:#}")                 # drop the empty element when grep matched nothing
+
+if (( ${#tags[@]} == 0 )); then
+  echo "No semver tags found on HEAD"
+  return 0
+fi
+
+local tag
+for tag in "${tags[@]}"; do
+  echo "Deleting tag $tag from HEAD"
+  git tag -d "$tag"
+done


### PR DESCRIPTION
Add git_delete_head_semver_tags, which deletes any local semver tags (vX.Y.Z or X.Y.Z) pointing at HEAD, and czbnt, which runs `cz bump` then calls it. `cz bump` has no skip-tag flag (--version-files-only also drops the commit), so this keeps the bump commit while removing the tag it creates, leaving the commit free to fixup/autosquash and tag later via git_tag_semver. Includes completions for both and README entries.