### PR TITLE
Harden installs and improve shell and Vim tooling

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 3.7.0
+  version: 3.8.0
   version_scheme: semver

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - name: Install zsh
+      run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh
+    - name: Run pre-commit on all files
+      run: pipx run pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,55 @@
+name: Install Smoke Test
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ubuntu:24.04        # dev container baseline — required
+            experimental: false
+          - image: rockylinux:9        # Red Hat fleet proxy — advisory (getRelease API rate limits can flake)
+            experimental: true
+          - image: opensuse/leap:15.6  # SUSE fleet proxy — advisory
+            experimental: true
+    continue-on-error: ${{ matrix.experimental }}
+    container: ${{ matrix.image }}
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+    - name: Bootstrap container prerequisites
+      shell: sh
+      # sudo is required by getRelease's default installcommand; tar/gzip by getRelease/install.sh
+      run: |
+        if command -v apt-get > /dev/null; then
+          apt-get update -qq && apt-get install -y -qq sudo git ca-certificates tar gzip
+        elif command -v dnf > /dev/null; then
+          dnf install -q -y sudo git ca-certificates tar gzip
+        elif command -v zypper > /dev/null; then
+          zypper -nq install sudo git ca-certificates tar gzip
+        else
+          echo "no supported package manager found" && exit 1
+        fi
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+    - name: Run installer (minimal mode)
+      run: ./install.sh
+    - name: Verify install results
+      run: |
+        test -L "$HOME/.zshrc"
+        test -d "$HOME/.oh-my-zsh"
+        for c in zsh getRelease bat fd fzf rg; do
+          command -v "$c" || { echo "missing: $c"; exit 1; }
+        done
+        TERM=xterm-256color zsh -ic 'echo SMOKE_OK' | grep -q SMOKE_OK

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,19 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         args: [ --markdown-linebreak-ext=md ]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: 745eface02aef23e168a8afb6b5737818efbea95  # frozen: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        # shellcheck cannot parse zsh; zsh files are covered by the zsh-syntax hook.
+        # omz/{install,configure}.sh are zsh, fzf-git.sh is vendored, git-template
+        # hooks are pre-commit-generated shims
+        exclude_types: [ zsh ]
+        exclude: ^(omz/(install|configure)\.sh|fzf/fzf-git\.sh|git/git-template/hooks/.*)$
+  - repo: local
+    hooks:
+      - id: zsh-syntax
+        name: zsh syntax check (zsh -n)
+        language: system
+        entry: bin/zsh_syntax_check
+        files: ^(omz/(functions|completions)/[^/]+|omz/zshrc|omz/(install|configure)\.sh|.*\.zsh)$

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+# scripts source user/omz files that shellcheck cannot resolve
+disable=SC1090,SC1091

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v3.8.0 (2026-07-05)
+
+### Feature
+
+- **vim**: prune bundle plugins no longer in the pinned list
+- **vim**: pin vim plugins to a sha to harden against supply chain attacks
+
+### Fix
+
+- **omz**: export terminal color variables after assignment
+- **fzf**: guard worktree switch against cd failure
+- **vim**: remove deprecated vim plugins
+- **vim**: remove obsolete plugin config
+- **omz**: add completion for depflow
+- **git**: add .claude/settings.local.json to global gitignore
+- harden package installs and downloads
+- **omz**: fix function bugs and portability issues
+- **omz**: harden omz install and configure scripts
+- **omz**: replace unescaped glob in ip4 alias
+
 ## v3.7.0 (2026-06-28)
 
 ### Feature

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -5,10 +5,12 @@ function cmd_exists() {
   command -v "${1}" &> /dev/null
 }
 
+# $elevate is exported by install.sh and must word-split ('' or 'sudo')
+# shellcheck disable=SC2086,SC2154
 function install_package() {
   if cmd_exists 'apt'; then
     $elevate /usr/bin/apt-get -qq update > /dev/null
-    $elevate /usr/bin/apt-get -qq install --allow-unauthenticated -y "$package" > /dev/null
+    $elevate /usr/bin/apt-get -qq install -y "$package" > /dev/null
   elif cmd_exists 'microdnf'; then
     $elevate /usr/bin/microdnf -q install -y "$package" > /dev/null
   elif cmd_exists 'yum'; then

--- a/bin/zsh_syntax_check
+++ b/bin/zsh_syntax_check
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# syntax-check zsh files; zsh -n only accepts one script per invocation
+set -u
+
+rc=0
+for f in "$@"; do
+  if ! zsh --no-rcs -n "$f"; then
+    echo "🔴 zsh syntax error: ${f}"
+    rc=1
+  fi
+done
+exit $rc

--- a/fzf/fzf.zsh
+++ b/fzf/fzf.zsh
@@ -30,6 +30,6 @@ if command -v fzf &> /dev/null; then
     _fzf_git_each_files | xargs git add
   }
   gswt() {
-    cd "$(_fzf_git_worktrees --no-multi)"
+    cd "$(_fzf_git_worktrees --no-multi)" || return
   }
 fi

--- a/getRelease/install.sh
+++ b/getRelease/install.sh
@@ -37,16 +37,29 @@ else
   temp_dir="$(mktemp -d)"
   trap cleanup EXIT
 
-  readonly archive_name="getRelease_Linux_$(detect_arch).tar.gz"
+  archive_name="getRelease_Linux_$(detect_arch).tar.gz"
+  readonly archive_name
   readonly archive_url="${release_url_base}/${archive_name}"
   readonly archive_path="${temp_dir}/${archive_name}"
   readonly extract_dir="${temp_dir}/extract"
-  readonly install_cmd="$(command -v install)"
+  install_cmd="$(command -v install)"
+  readonly install_cmd
 
   mkdir -p "${extract_dir}"
 
   if ! curl -fsSL "${archive_url}" -o "${archive_path}"; then
     echo "🔴 failed to download ${archive_name} from ${archive_url}"
+    exit 1
+  fi
+
+  # verify the archive against the release's published checksums before extracting
+  if ! curl -fsSL "${release_url_base}/checksums.txt" -o "${temp_dir}/checksums.txt"; then
+    echo "🔴 failed to download checksums.txt from ${release_url_base}"
+    exit 1
+  fi
+
+  if ! (cd "${temp_dir}" && sha256sum --check --quiet --ignore-missing checksums.txt); then
+    echo "🔴 checksum verification failed for ${archive_name}"
     exit 1
   fi
 
@@ -58,6 +71,7 @@ else
     exit 1
   fi
 
+  # shellcheck disable=SC2086,SC2154  # $elevate is exported by install.sh and must word-split
   $elevate "${install_cmd}" -m 0755 -o root -g root "${binary_path}" "${install_path}"
 
   if [[ ! -x "${install_path}" ]]; then

--- a/git/gitignore_global
+++ b/git/gitignore_global
@@ -3,3 +3,5 @@
 *.code-workspace
 *.swp
 .DS_Store
+
+**/.claude/settings.local.json

--- a/install.sh
+++ b/install.sh
@@ -7,13 +7,18 @@ set -e
 ###
 
 # DOTFILES repo path
-export DOTFILES_LOCATION=$(pwd)
+DOTFILES_LOCATION="$(pwd)"
+export DOTFILES_LOCATION
 
 # INSTALL_MODE == 'full' for workstation, else minimal for devcontainers
 export INSTALL_MODE="${1}"
 
 # create elevate variable to use sudo if needed
-[ "$EUID" -eq 0 ] && elevate='' || elevate='sudo'
+if [ "$EUID" -eq 0 ]; then
+  elevate=''
+else
+  elevate='sudo'
+fi
 export elevate
 
 ###

--- a/omz/README.md
+++ b/omz/README.md
@@ -8,7 +8,6 @@ This directory contains the Zsh and Oh My Zsh configuration for the dotfiles rep
 
 - **`zshrc`** - Main Zsh configuration file, symlinked to `~/.zshrc`
 - **`p10k.zsh`** - Powerlevel10k theme configuration, symlinked to `~/.p10k.zsh`
-- **`env.zsh`** - Environment setup, symlinked to `$ZSH_CUSTOM/env.zsh`
 - **`variables.zsh`** - Shell variables, symlinked to `$ZSH_CUSTOM/variables.zsh`
 - **`aliases.zsh`** - Shell aliases, symlinked to `$ZSH_CUSTOM/aliases.zsh`
 
@@ -33,20 +32,24 @@ This directory contains the Zsh and Oh My Zsh configuration for the dotfiles rep
 
 #### `functions/`
 
-Individual function files that are autoloaded on-demand. Each file contains a single function:
+Individual function files that are autoloaded on-demand. Each file contains a single function. Files prefixed with `_` are internal helpers used by the other functions:
 
+- **`ccm`** - Generate a commit message for staged changes with the `copilot` CLI, then commit with it
 - **`cdr`** - Fuzzy-select a git repository under `~/gitrepos` and `cd` into it
+- **`copipe`** - Pipe stdin or a file to the `copilot` CLI with a prompt
 - **`countdown`** - Timer countdown utility
 - **`czbnt`** - `cz bump`, then strip the semver tag it leaves on HEAD
 - **`decode_cert`** - Decode SSL/TLS certificates
 - **`decode_jwt`** - Decode JWT tokens
 - **`ff`** - Fuzzy-find a file and open it in `$EDITOR`
 - **`fp`** - Podman fzf helpers dispatcher (`fpe`, `fpse`, `fpa`, `fpsa`, `fps`, `fprm`, `fprmi`, `fpl`, `fpst`, `fprestart`); run `fp help` for details
+- **`gcfuh`** - Interactively create fixup commits targeting the commits that last touched the changed lines
 - **`gciaf`** - `git commit -a --fixup` for a commit
 - **`gcif`** - `git commit --fixup` for a commit
 - **`gdu`** - `git diff` with 0 lines of context
 - **`gdus`** - `git diff --cached` with 0 lines of context
 - **`get_k8s_images`** - Extract container images from Kubernetes pods with filtering and parsing options
+- **`ghist`** - Show commit history since the branch base
 - **`git_delete_head_semver_tags`** - Delete local semver tags pointing at HEAD (e.g. the one `cz bump` creates)
 - **`git_find_branch_base`** - Find the base branch name or merge-base commit (main/master/develop/...)
 - **`git_pr_check`** - Check subdirectories for GitHub pull requests
@@ -54,31 +57,37 @@ Individual function files that are autoloaded on-demand. Each file contains a si
 - **`grias`** - `git rebase --interactive --autosquash` from the branch base
 - **`gundo`** - Undo the last commit (soft reset, keeps changes staged)
 - **`install_it`** - Use Linux `install` to install binaries in `/usr/local/bin`
-- **`install_kubectl`** - Install or upgrade kubectl to a specific version
+- **`install_kubectl`** - Install or upgrade kubectl to a specific version (checksum-verified)
 - **`joincsv`** - Join two CSV files by their first column
-- **`log_cmd`** - Command logging utility
-- **`log_cmd_d`** - Command logging utility to default path: `/tmp/cmd-$(date).log`
+- **`log_cmd`** - Command logging utility (default log: `~/command.log`, override with `CMD_LOG_FILE`)
+- **`log_cmd_d`** - Command logging utility to a unique timestamped file under `$TMPDIR`
 - **`pprint`** - Pretty print utility
 - **`rgf`** - Fuzzy-find a file containing a pattern and open it at the match in `$EDITOR`
 - **`update_git_mirrors_in_subdirs`** - Fetch and mirror-push every git repo in the current directory's subdirectories
+- **`update_omz_all`** - Update oh-my-zsh itself plus all custom themes/plugins (`--dry-run` supported)
 
 #### `completions/`
 
-Zsh completion functions (prefixed with `_`) symlinked to `$ZSH_CUSTOM/completions/`:
+Zsh completion functions (prefixed with `_`) symlinked to `$ZSH_CUSTOM/completions/`.
 
-- **`_czbnt`** - Completion for czbnt function
-- **`_decode_cert`** - Completion for decode_cert function
-- **`_decode_jwt`** - Completion for decode_jwt function
-- **`_git_delete_head_semver_tags`** - Completion for git_delete_head_semver_tags function
-- **`_fzf`** - FZF completion
-- **`_getRelease`** - Completion for getRelease CLI
-- **`_install_it`** - Completion for install_it function
+Hand-written completions for the custom functions above: `_copipe`, `_czbnt`, `_decode_cert`, `_decode_jwt`, `_gcfuh`, `_gciaf`, `_gcif`, `_gdu`, `_gdus`, `_get_k8s_images`, `_ghist`, `_git_delete_head_semver_tags`, `_git_tag_semver`, `_install_it`, plus the shared helper `_commits_since_merge`.
+
+Generated/vendored completions: `_bat`, `_fd`, `_rg` (shipped by the upstream tools) and `_getRelease`, `_depflow` (Cobra-generated for external CLIs).
 
 #### `scripts/`
 
 Standalone scripts for specific tasks:
 
 - **`merge_kube_configs.zsh`** - Merge multiple kubeconfig files
+
+## Sharp Edges
+
+A few commands are deliberately powerful — know what they do before running them:
+
+- **`gitrebaseall`** (alias) - rebases every local branch onto the default branch and **force-pushes each one** to origin
+- **`update_git_mirrors_in_subdirs`** - runs `git push --mirror` in every subdirectory repo, which **deletes remote refs that don't exist locally**
+- **`sssh` / `sscp`** (aliases) - ssh/scp with host-key checking disabled (`StrictHostKeyChecking=no`, throwaway known_hosts); convenient for ephemeral hosts, but offers no MITM protection
+- **`ccm` / `copipe`** - send staged diffs / arbitrary input to GitHub Copilot, i.e. off the machine
 
 ## Adding New Functions
 

--- a/omz/aliases.zsh
+++ b/omz/aliases.zsh
@@ -4,7 +4,7 @@ alias dutop='sudo du -m --max-depth=1 . | sort -nr | head -n50'
 alias grep='grep --color=auto'
 alias grepify=' tr -s "\n" "|" | sed "s/|$//"'
 alias h='history'
-alias ip4="/?bin/ip -o -4 a | grep -v ': lo' | sed 's/[0-9]\+\:\s*//;s/\// \//' | column -t"
+alias ip4="command ip -o -4 a | grep -v ': lo' | sed 's/[0-9]\+\:\s*//;s/\// \//' | column -t"
 alias l='ls -alF'
 alias la='ls -la'
 alias lal='ls -altr'

--- a/omz/completions/_depflow
+++ b/omz/completions/_depflow
@@ -1,0 +1,212 @@
+#compdef depflow
+compdef _depflow depflow
+
+# zsh completion for depflow                              -*- shell-script -*-
+
+__depflow_debug()
+{
+    local file="$BASH_COMP_DEBUG_FILE"
+    if [[ -n ${file} ]]; then
+        echo "$*" >> "${file}"
+    fi
+}
+
+_depflow()
+{
+    local shellCompDirectiveError=1
+    local shellCompDirectiveNoSpace=2
+    local shellCompDirectiveNoFileComp=4
+    local shellCompDirectiveFilterFileExt=8
+    local shellCompDirectiveFilterDirs=16
+    local shellCompDirectiveKeepOrder=32
+
+    local lastParam lastChar flagPrefix requestComp out directive comp lastComp noSpace keepOrder
+    local -a completions
+
+    __depflow_debug "\n========= starting completion logic =========="
+    __depflow_debug "CURRENT: ${CURRENT}, words[*]: ${words[*]}"
+
+    # The user could have moved the cursor backwards on the command-line.
+    # We need to trigger completion from the $CURRENT location, so we need
+    # to truncate the command-line ($words) up to the $CURRENT location.
+    # (We cannot use $CURSOR as its value does not work when a command is an alias.)
+    words=("${=words[1,CURRENT]}")
+    __depflow_debug "Truncated words[*]: ${words[*]},"
+
+    lastParam=${words[-1]}
+    lastChar=${lastParam[-1]}
+    __depflow_debug "lastParam: ${lastParam}, lastChar: ${lastChar}"
+
+    # For zsh, when completing a flag with an = (e.g., depflow -n=<TAB>)
+    # completions must be prefixed with the flag
+    setopt local_options BASH_REMATCH
+    if [[ "${lastParam}" =~ '-.*=' ]]; then
+        # We are dealing with a flag with an =
+        flagPrefix="-P ${BASH_REMATCH}"
+    fi
+
+    # Prepare the command to obtain completions
+    requestComp="${words[1]} __complete ${words[2,-1]}"
+    if [ "${lastChar}" = "" ]; then
+        # If the last parameter is complete (there is a space following it)
+        # We add an extra empty parameter so we can indicate this to the go completion code.
+        __depflow_debug "Adding extra empty parameter"
+        requestComp="${requestComp} \"\""
+    fi
+
+    __depflow_debug "About to call: eval ${requestComp}"
+
+    # Use eval to handle any environment variables and such
+    out=$(eval ${requestComp} 2>/dev/null)
+    __depflow_debug "completion output: ${out}"
+
+    # Extract the directive integer following a : from the last line
+    local lastLine
+    while IFS='\n' read -r line; do
+        lastLine=${line}
+    done < <(printf "%s\n" "${out[@]}")
+    __depflow_debug "last line: ${lastLine}"
+
+    if [ "${lastLine[1]}" = : ]; then
+        directive=${lastLine[2,-1]}
+        # Remove the directive including the : and the newline
+        local suffix
+        (( suffix=${#lastLine}+2))
+        out=${out[1,-$suffix]}
+    else
+        # There is no directive specified.  Leave $out as is.
+        __depflow_debug "No directive found.  Setting do default"
+        directive=0
+    fi
+
+    __depflow_debug "directive: ${directive}"
+    __depflow_debug "completions: ${out}"
+    __depflow_debug "flagPrefix: ${flagPrefix}"
+
+    if [ $((directive & shellCompDirectiveError)) -ne 0 ]; then
+        __depflow_debug "Completion received error. Ignoring completions."
+        return
+    fi
+
+    local activeHelpMarker="_activeHelp_ "
+    local endIndex=${#activeHelpMarker}
+    local startIndex=$((${#activeHelpMarker}+1))
+    local hasActiveHelp=0
+    while IFS='\n' read -r comp; do
+        # Check if this is an activeHelp statement (i.e., prefixed with $activeHelpMarker)
+        if [ "${comp[1,$endIndex]}" = "$activeHelpMarker" ];then
+            __depflow_debug "ActiveHelp found: $comp"
+            comp="${comp[$startIndex,-1]}"
+            if [ -n "$comp" ]; then
+                compadd -x "${comp}"
+                __depflow_debug "ActiveHelp will need delimiter"
+                hasActiveHelp=1
+            fi
+
+            continue
+        fi
+
+        if [ -n "$comp" ]; then
+            # If requested, completions are returned with a description.
+            # The description is preceded by a TAB character.
+            # For zsh's _describe, we need to use a : instead of a TAB.
+            # We first need to escape any : as part of the completion itself.
+            comp=${comp//:/\\:}
+
+            local tab="$(printf '\t')"
+            comp=${comp//$tab/:}
+
+            __depflow_debug "Adding completion: ${comp}"
+            completions+=${comp}
+            lastComp=$comp
+        fi
+    done < <(printf "%s\n" "${out[@]}")
+
+    # Add a delimiter after the activeHelp statements, but only if:
+    # - there are completions following the activeHelp statements, or
+    # - file completion will be performed (so there will be choices after the activeHelp)
+    if [ $hasActiveHelp -eq 1 ]; then
+        if [ ${#completions} -ne 0 ] || [ $((directive & shellCompDirectiveNoFileComp)) -eq 0 ]; then
+            __depflow_debug "Adding activeHelp delimiter"
+            compadd -x "--"
+            hasActiveHelp=0
+        fi
+    fi
+
+    if [ $((directive & shellCompDirectiveNoSpace)) -ne 0 ]; then
+        __depflow_debug "Activating nospace."
+        noSpace="-S ''"
+    fi
+
+    if [ $((directive & shellCompDirectiveKeepOrder)) -ne 0 ]; then
+        __depflow_debug "Activating keep order."
+        keepOrder="-V"
+    fi
+
+    if [ $((directive & shellCompDirectiveFilterFileExt)) -ne 0 ]; then
+        # File extension filtering
+        local filteringCmd
+        filteringCmd='_files'
+        for filter in ${completions[@]}; do
+            if [ ${filter[1]} != '*' ]; then
+                # zsh requires a glob pattern to do file filtering
+                filter="\*.$filter"
+            fi
+            filteringCmd+=" -g $filter"
+        done
+        filteringCmd+=" ${flagPrefix}"
+
+        __depflow_debug "File filtering command: $filteringCmd"
+        _arguments '*:filename:'"$filteringCmd"
+    elif [ $((directive & shellCompDirectiveFilterDirs)) -ne 0 ]; then
+        # File completion for directories only
+        local subdir
+        subdir="${completions[1]}"
+        if [ -n "$subdir" ]; then
+            __depflow_debug "Listing directories in $subdir"
+            pushd "${subdir}" >/dev/null 2>&1
+        else
+            __depflow_debug "Listing directories in ."
+        fi
+
+        local result
+        _arguments '*:dirname:_files -/'" ${flagPrefix}"
+        result=$?
+        if [ -n "$subdir" ]; then
+            popd >/dev/null 2>&1
+        fi
+        return $result
+    else
+        __depflow_debug "Calling _describe"
+        if eval _describe $keepOrder "completions" completions $flagPrefix $noSpace; then
+            __depflow_debug "_describe found some completions"
+
+            # Return the success of having called _describe
+            return 0
+        else
+            __depflow_debug "_describe did not find completions."
+            __depflow_debug "Checking if we should do file completion."
+            if [ $((directive & shellCompDirectiveNoFileComp)) -ne 0 ]; then
+                __depflow_debug "deactivating file completion"
+
+                # We must return an error code here to let zsh know that there were no
+                # completions found by _describe; this is what will trigger other
+                # matching algorithms to attempt to find completions.
+                # For example zsh can match letters in the middle of words.
+                return 1
+            else
+                # Perform file completion
+                __depflow_debug "Activating file completion"
+
+                # We must return the result of this command, so it must be the
+                # last command, or else we must store its result to return it.
+                _arguments '*:filename:_files'" ${flagPrefix}"
+            fi
+        fi
+    fi
+}
+
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_depflow" ]; then
+    _depflow
+fi

--- a/omz/configure.sh
+++ b/omz/configure.sh
@@ -1,74 +1,79 @@
 #!/usr/bin/env zsh
 
+set -eu
+: "${DOTFILES_LOCATION:?DOTFILES_LOCATION must be set to the dotfiles repo path}"
+
+zsh_custom="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+
 # powerlevel10k theme
-if [ -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k" ]; then
+if [ -d "${zsh_custom}/themes/powerlevel10k" ]; then
   echo "Updating powerlevel10k theme"
-  git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k" pull --quiet
+  git -C "${zsh_custom}/themes/powerlevel10k" pull --quiet || echo "⚠️ powerlevel10k update failed, continuing"
 else
   echo "Installing powerlevel10k theme"
-  git clone --quiet --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
-  ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k/gitstatus/install
+  git clone --quiet --depth=1 https://github.com/romkatv/powerlevel10k.git "${zsh_custom}/themes/powerlevel10k"
+  "${zsh_custom}/themes/powerlevel10k/gitstatus/install"
 fi
 
 # zsh syntax highlighting
-if [ -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting" ]; then
+if [ -d "${zsh_custom}/plugins/zsh-syntax-highlighting" ]; then
   echo "Updating zsh syntax highlighting"
-  git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting" pull --quiet
+  git -C "${zsh_custom}/plugins/zsh-syntax-highlighting" pull --quiet || echo "⚠️ zsh-syntax-highlighting update failed, continuing"
 else
   echo "Installing zsh syntax highlighting"
-  git clone --quiet https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+  git clone --quiet https://github.com/zsh-users/zsh-syntax-highlighting.git "${zsh_custom}/plugins/zsh-syntax-highlighting"
 fi
 
 # zsh autosuggestions
-if [ -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions" ]; then
+if [ -d "${zsh_custom}/plugins/zsh-autosuggestions" ]; then
   echo "Updating zsh autosuggestions"
-  git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions" pull --quiet
+  git -C "${zsh_custom}/plugins/zsh-autosuggestions" pull --quiet || echo "⚠️ zsh-autosuggestions update failed, continuing"
 else
   echo "Installing zsh autosuggestions"
-  git clone --quiet https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+  git clone --quiet https://github.com/zsh-users/zsh-autosuggestions "${zsh_custom}/plugins/zsh-autosuggestions"
 fi
 
 # fzf-tab
-if [ -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/fzf-tab" ]; then
+if [ -d "${zsh_custom}/plugins/fzf-tab" ]; then
   echo "Updating fzf-tab"
-  git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/fzf-tab" pull --quiet
+  git -C "${zsh_custom}/plugins/fzf-tab" pull --quiet || echo "⚠️ fzf-tab update failed, continuing"
 else
   echo "Installing fzf-tab"
-  git clone --quiet https://github.com/Aloxaf/fzf-tab "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/fzf-tab"
+  git clone --quiet https://github.com/Aloxaf/fzf-tab "${zsh_custom}/plugins/fzf-tab"
 fi
 
-ln -sf "${DOTFILES_LOCATION}/omz/aliases.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/aliases.zsh"
-ln -sf --no-dereference "${DOTFILES_LOCATION}/omz/functions" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/functions"
-ln -sf "${DOTFILES_LOCATION}/omz/variables.zsh" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/variables.zsh"
+ln -sf "${DOTFILES_LOCATION}/omz/aliases.zsh" "${zsh_custom}/aliases.zsh"
+ln -sf --no-dereference "${DOTFILES_LOCATION}/omz/functions" "${zsh_custom}/functions"
+ln -sf "${DOTFILES_LOCATION}/omz/variables.zsh" "${zsh_custom}/variables.zsh"
 ln -sf "${DOTFILES_LOCATION}/omz/zshrc" "${HOME}/.zshrc"
 ln -sf "${DOTFILES_LOCATION}/omz/p10k.zsh" "${HOME}/.p10k.zsh"
 
 # remove any dead symlinks from the zsh custom directory
-if [ -e "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" ]; then
-  find "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}" -maxdepth 1 -type l ! -exec test -e {} \; -delete
+if [ -e "${zsh_custom}" ]; then
+  find "${zsh_custom}" -maxdepth 1 -type l ! -exec test -e {} \; -delete
 fi
 
 # remove any dead symlinks from the custom completions directory or create it if it doesn't exist
-if [ -e "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions" ]; then
-  find "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions" -type l ! -exec test -e {} \; -delete
+if [ -e "${zsh_custom}/completions" ]; then
+  find "${zsh_custom}/completions" -maxdepth 1 -type l ! -exec test -e {} \; -delete
 else
-  mkdir "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions"
+  mkdir -p "${zsh_custom}/completions"
 fi
 
 # loop over all completions and symlink them
 for completion in "${DOTFILES_LOCATION}/omz/completions"/*; do
-  ln -sf "${completion}" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/completions/$(basename ${completion})"
+  ln -sf "${completion}" "${zsh_custom}/completions/$(basename "${completion}")"
 done
 
 ### SETUP CUSTOM SCRIPTS ###
 # remove any dead symlinks from the custom scripts directory or create it if it doesn't exist
 if [ -e "${HOME}/bin" ]; then
-  find "${HOME}/bin" -type l ! -exec test -e {} \; -delete
+  find "${HOME}/bin" -maxdepth 1 -type l ! -exec test -e {} \; -delete
 else
-  mkdir "${HOME}/bin"
+  mkdir -p "${HOME}/bin"
 fi
 
 # loop over all custom scripts and symlink them
 for custom_script in "${DOTFILES_LOCATION}/omz/scripts"/*; do
-  ln -sf "${custom_script}" "${HOME}/bin/$(basename ${custom_script})"
+  ln -sf "${custom_script}" "${HOME}/bin/$(basename "${custom_script}")"
 done

--- a/omz/functions/cdr
+++ b/omz/functions/cdr
@@ -7,9 +7,14 @@
 # Returns:
 #   0 on success, 1 if no selection made
 #######################################
-local repo
+local repo fd_cmd
+# debian/ubuntu package fd as fdfind
+fd_cmd=$(command -v fd || command -v fdfind) || {
+  pprint "🔴 fd is required, but not found." "$fgRed" >&2
+  return 1
+}
 repo=$(
-  fd --unrestricted --type d --glob '.git' "$HOME/gitrepos" 2>/dev/null |
+  "$fd_cmd" --unrestricted --type d --glob '.git' "$HOME/gitrepos" 2>/dev/null |
     sed 's#/.git/\?$##' |
     fzf --prompt='repo> '
 ) || return 1

--- a/omz/functions/decode_cert
+++ b/omz/functions/decode_cert
@@ -104,7 +104,7 @@ case "$target_type" in
   domain|url)
     target=$(sed -E 's/(https:\/\/|ftps:\/\/)//;s/\/.*//' <<< "$target")
     # validate the domain name is resolvable
-    if ! host "${target%%:*}" &>/dev/null; then
+    if ! getent hosts "${target%%:*}" &>/dev/null; then
       pprint "🔴 $target is not resolvable" "$fgRed" >&2
       return 1
     fi

--- a/omz/functions/git_pr_check
+++ b/omz/functions/git_pr_check
@@ -15,9 +15,9 @@ fi
 local current_dir dir
 current_dir=$(pwd)
 for dir in "${1:-.}"/*(/N); do
-  cd "$dir"
+  cd "$dir" || continue
   # has a .git directory
-  if [ -d .git -o -d refs ]; then
+  if [[ -d .git || -d refs ]]; then
     # has a GitHub remote
     if git remote -v | grep -iq github; then
       echo

--- a/omz/functions/install_kubectl
+++ b/omz/functions/install_kubectl
@@ -16,23 +16,56 @@ EOF
   return 0
 fi
 
-local version=""
+local arch version tmp_dir
+case "$(uname -m)" in
+  x86_64|amd64) arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *)
+    pprint "🔴 unsupported architecture: $(uname -m)" "$fgRed" >&2
+    return 1
+    ;;
+esac
+
 if [ -n "$1" ]; then
     # test if the version is valid
-    if [[ "$1" =~ '^[0-9]\.[0-9]{2}$' ]]; then
-      version="$(/usr/bin/curl -L -s https://dl.k8s.io/release/stable-${1}.txt)"
+    if [[ "$1" =~ '^[0-9]+\.[0-9]+$' ]]; then
+      version="$(curl -fsSL "https://dl.k8s.io/release/stable-${1}.txt")"
     else
-      pprint "🔴 invalid version format, please use the format X.YY" "$fgRed" >&2
+      pprint "🔴 invalid version format, please use the format X.Y" "$fgRed" >&2
       return 1
     fi
 elif [ -z "$1" ]; then
-    version="$(/usr/bin/curl -L -s https://dl.k8s.io/release/stable.txt)"
+    version="$(curl -fsSL https://dl.k8s.io/release/stable.txt)"
 fi
 
-/usr/bin/curl  -o ~/install/kubectl -L "https://dl.k8s.io/release/${version}/bin/linux/amd64/kubectl"
-if [ $? -ne 0 ]; then
-  pprint "🔴 failed to download kubectl ${version}" "$fgRed" >&2
+if [[ ! "$version" =~ '^v[0-9]' ]]; then
+  pprint "🔴 failed to determine kubectl version to install" "$fgRed" >&2
   return 1
 fi
-sudo /usr/bin/install -o root -g root -m 0755 ~/install/kubectl /usr/local/bin/kubectl
-[ $? -eq 0 ] && pprint "📦 Installed kubectl ${version}" "$fgGreen"
+
+tmp_dir="$(mktemp -d)" || return 1
+if ! curl -fsSL -o "${tmp_dir}/kubectl" "https://dl.k8s.io/release/${version}/bin/linux/${arch}/kubectl"; then
+  pprint "🔴 failed to download kubectl ${version}" "$fgRed" >&2
+  rm -rf "${tmp_dir}"
+  return 1
+fi
+
+# verify the download against its published sha256 before installing
+if ! curl -fsSL -o "${tmp_dir}/kubectl.sha256" "https://dl.k8s.io/release/${version}/bin/linux/${arch}/kubectl.sha256"; then
+  pprint "🔴 failed to download checksum for kubectl ${version}" "$fgRed" >&2
+  rm -rf "${tmp_dir}"
+  return 1
+fi
+if ! echo "$(cat "${tmp_dir}/kubectl.sha256")  ${tmp_dir}/kubectl" | sha256sum --check --quiet; then
+  pprint "🔴 checksum verification failed for kubectl ${version}" "$fgRed" >&2
+  rm -rf "${tmp_dir}"
+  return 1
+fi
+
+if ! sudo install -o root -g root -m 0755 "${tmp_dir}/kubectl" /usr/local/bin/kubectl; then
+  pprint "🔴 failed to install kubectl ${version}" "$fgRed" >&2
+  rm -rf "${tmp_dir}"
+  return 1
+fi
+pprint "📦 Installed kubectl ${version}" "$fgGreen"
+rm -rf "${tmp_dir}"

--- a/omz/functions/log_cmd
+++ b/omz/functions/log_cmd
@@ -7,7 +7,7 @@ Usage: log_cmd <command>
 Log a shell command, its stdout, and stderr to a file.
 
 Variables:
-  CMD_LOG_FILE - the file to log the command and its output to (default: /tmp/command.log)
+  CMD_LOG_FILE - the file to log the command and its output to (default: ~/command.log)
 
 Arguments:
   command  Command to execute and log.
@@ -17,16 +17,16 @@ fi
 
 local header="####################################################\n"
 
-# check if log file has been named
+# check if log file has been named; default lives in $HOME, not world-writable /tmp
 if [ -z "${CMD_LOG_FILE}" ]; then
-  local CMD_LOG_FILE="/tmp/command.log"
+  local CMD_LOG_FILE="${HOME}/command.log"
   pprint "🔵 No log file specified, using default: ${CMD_LOG_FILE}" "$fgBlue"
 fi
 
 {
-  printf "${header}"
+  printf '%b' "${header}"
   printf "\`%s\` executed at $(date '+%Y-%m-%d %H:%M:%S')\n" "$*"
-  printf "${header}"
+  printf '%b' "${header}"
   "$@"
   printf "\n"
 } 2>&1 | tee -a "${CMD_LOG_FILE}"

--- a/omz/functions/log_cmd_d
+++ b/omz/functions/log_cmd_d
@@ -14,10 +14,15 @@ fi
 
 local header="####################################################\n"
 
+# mktemp avoids clobbering/symlink games with a predictable name in world-writable /tmp
+local log_file
+log_file="$(mktemp "${TMPDIR:-/tmp}/cmd-$(date '+%Y_%m_%d_%H-%M-%S')-XXXXXX.log")" || return 1
+pprint "🔵 logging to ${log_file}" "$fgBlue"
+
 {
-  printf "${header}"
+  printf '%b' "${header}"
   printf "Command executed: %s\n\n" "$*"
-  printf "${header}"
+  printf '%b' "${header}"
   "$@"
   printf "\n"
-} 2>&1 | tee "/tmp/cmd-$(date '+%Y_%m_%d_%H-%M-%S').log"
+} 2>&1 | tee "${log_file}"

--- a/omz/install.sh
+++ b/omz/install.sh
@@ -5,5 +5,10 @@ set -e
 if [ -d "${HOME}/.oh-my-zsh" ]; then
   echo "🟢 oh-my-zsh is already installed"
 else
-  sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended > /dev/null
+  # capture the installer first so a failed download is fatal instead of silently running `sh -c ""`
+  installer="$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" || {
+    echo "🔴 failed to download oh-my-zsh installer"
+    exit 1
+  }
+  sh -c "${installer}" "" --unattended > /dev/null
 fi

--- a/omz/variables.zsh
+++ b/omz/variables.zsh
@@ -3,47 +3,47 @@
 [[ -z "$TERM" ]] && return
 
 # background color using ANSI escape
-[ -z $bgBlack ]     && declare -r bgBlack=$(tput setab 0)    && export bgBlack       # black
-[ -z $bgRed ]       && declare -r bgRed=$(tput setab 1)      && export bgRed         # red
-[ -z $bgGreen ]     && declare -r bgGreen=$(tput setab 2)    && export bgGreen       # green
-[ -z $bgYellow ]    && declare -r bgYellow=$(tput setab 3)   && export bgYellow      # yellow
-[ -z $bgBlue ]      && declare -r bgBlue=$(tput setab 4)     && export bgBlue        # blue
-[ -z $bgMagenta ]   && declare -r bgMagenta=$(tput setab 5)  && export bgMagenta     # magenta
-[ -z $bgCyan ]      && declare -r bgCyan=$(tput setab 6)     && export bgCyan        # cyan
-[ -z $bgWhite ]     && declare -r bgWhite=$(tput setab 7)    && export bgWhite       # white
-[ -z $bgPurple ]    && declare -r bgPurple=$(tput setab 99)  && export bgPurple      # purple
-[ -z $bgPink ]      && declare -r bgPink=$(tput setab 171)   && export bgPink        # pink
-[ -z $bgOrange ]    && declare -r bgOrange=$(tput setab 172) && export bgOrange      # orange
-[ -z $bgDkGrey ]    && declare -r bgDkGrey=$(tput setab 237) && export bgDkGrey      # dark grey
-[ -z $bgGrey ]      && declare -r bgGrey=$(tput setab 243)   && export bgGrey        # grey
-[ -z $bgLtGrey ]    && declare -r bgLtGrey=$(tput setab 249) && export bgLtGrey      # light grey
+(( ${+bgBlack} ))     || { bgBlack=$(tput setab 0)    && declare -rx bgBlack }     # black
+(( ${+bgRed} ))       || { bgRed=$(tput setab 1)      && declare -rx bgRed }       # red
+(( ${+bgGreen} ))     || { bgGreen=$(tput setab 2)    && declare -rx bgGreen }     # green
+(( ${+bgYellow} ))    || { bgYellow=$(tput setab 3)   && declare -rx bgYellow }    # yellow
+(( ${+bgBlue} ))      || { bgBlue=$(tput setab 4)     && declare -rx bgBlue }      # blue
+(( ${+bgMagenta} ))   || { bgMagenta=$(tput setab 5)  && declare -rx bgMagenta }   # magenta
+(( ${+bgCyan} ))      || { bgCyan=$(tput setab 6)     && declare -rx bgCyan }      # cyan
+(( ${+bgWhite} ))     || { bgWhite=$(tput setab 7)    && declare -rx bgWhite }     # white
+(( ${+bgPurple} ))    || { bgPurple=$(tput setab 99)  && declare -rx bgPurple }    # purple
+(( ${+bgPink} ))      || { bgPink=$(tput setab 171)   && declare -rx bgPink }      # pink
+(( ${+bgOrange} ))    || { bgOrange=$(tput setab 172) && declare -rx bgOrange }    # orange
+(( ${+bgDkGrey} ))    || { bgDkGrey=$(tput setab 237) && declare -rx bgDkGrey }    # dark grey
+(( ${+bgGrey} ))      || { bgGrey=$(tput setab 243)   && declare -rx bgGrey }      # grey
+(( ${+bgLtGrey} ))    || { bgLtGrey=$(tput setab 249) && declare -rx bgLtGrey }    # light grey
 
 # foreground color using ANSI escape
-[ -z $fgBlack ]     && declare -r fgBlack=$(tput setaf 0)    && export fgBlack       # black
-[ -z $fgRed ]       && declare -r fgRed=$(tput setaf 1)      && export fgRed         # red
-[ -z $fgGreen ]     && declare -r fgGreen=$(tput setaf 2)    && export fgGreen       # green
-[ -z $fgYellow ]    && declare -r fgYellow=$(tput setaf 3)   && export fgYellow      # yellow
-[ -z $fgBlue ]      && declare -r fgBlue=$(tput setaf 4)     && export fgBlue        # blue
-[ -z $fgMagenta ]   && declare -r fgMagenta=$(tput setaf 5)  && export fgMagenta     # magenta
-[ -z $fgCyan ]      && declare -r fgCyan=$(tput setaf 6)     && export fgCyan        # cyan
-[ -z $fgWhite ]     && declare -r fgWhite=$(tput setaf 7)    && export fgWhite       # white
-[ -z $fgPurple ]    && declare -r fgPurple=$(tput setaf 99)  && export fgPurple      # purple
-[ -z $fgPink ]      && declare -r fgPink=$(tput setaf 171)   && export fgPink        # pink
-[ -z $fgOrange ]    && declare -r fgOrange=$(tput setaf 172) && export fgOrange      # orange
-[ -z $fgDkGrey ]    && declare -r fgDkGrey=$(tput setaf 237) && export fgDkGrey      # dark grey
-[ -z $fgGrey ]      && declare -r fgGrey=$(tput setaf 243)   && export fgGrey        # grey
-[ -z $fgLtGrey ]    && declare -r fgLtGrey=$(tput setaf 249) && export fgLtGrey      # light grey
+(( ${+fgBlack} ))     || { fgBlack=$(tput setaf 0)    && declare -rx fgBlack }     # black
+(( ${+fgRed} ))       || { fgRed=$(tput setaf 1)      && declare -rx fgRed }       # red
+(( ${+fgGreen} ))     || { fgGreen=$(tput setaf 2)    && declare -rx fgGreen }     # green
+(( ${+fgYellow} ))    || { fgYellow=$(tput setaf 3)   && declare -rx fgYellow }    # yellow
+(( ${+fgBlue} ))      || { fgBlue=$(tput setaf 4)     && declare -rx fgBlue }      # blue
+(( ${+fgMagenta} ))   || { fgMagenta=$(tput setaf 5)  && declare -rx fgMagenta }   # magenta
+(( ${+fgCyan} ))      || { fgCyan=$(tput setaf 6)     && declare -rx fgCyan }      # cyan
+(( ${+fgWhite} ))     || { fgWhite=$(tput setaf 7)    && declare -rx fgWhite }     # white
+(( ${+fgPurple} ))    || { fgPurple=$(tput setaf 99)  && declare -rx fgPurple }    # purple
+(( ${+fgPink} ))      || { fgPink=$(tput setaf 171)   && declare -rx fgPink }      # pink
+(( ${+fgOrange} ))    || { fgOrange=$(tput setaf 172) && declare -rx fgOrange }    # orange
+(( ${+fgDkGrey} ))    || { fgDkGrey=$(tput setaf 237) && declare -rx fgDkGrey }    # dark grey
+(( ${+fgGrey} ))      || { fgGrey=$(tput setaf 243)   && declare -rx fgGrey }      # grey
+(( ${+fgLtGrey} ))    || { fgLtGrey=$(tput setaf 249) && declare -rx fgLtGrey }    # light grey
 
 # podman fzf-helper (fp*) table formats, consumed by the autoloaded fp* functions
 (( ${+_FP_CONTAINER_FORMAT} )) || typeset -gr _FP_CONTAINER_FORMAT=$'{{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'
 (( ${+_FP_IMAGE_FORMAT} ))     || typeset -gr _FP_IMAGE_FORMAT=$'{{.ID}}\t{{.Repository}}:{{.Tag}}\t{{.CreatedSince}}\t{{.Size}}'
 
 # text attributes using ANSI escape
-[ -z $txBold ]      && declare -r txBold=$(tput bold)        && export txBold        # bold
-[ -z $txHalf ]      && declare -r txHalf=$(tput dim)         && export txHalf        # half-bright
-[ -z $txUnderline ] && declare -r txUnderline=$(tput smul)   && export txUnderline  # underline
-[ -z $txEndUnder ]  && declare -r txEndUnder=$(tput rmul)    && export txEndUnder   # exit underline
-[ -z $txReverse ]   && declare -r txReverse=$(tput rev)      && export txReverse    # reverse
-[ -z $txStandout ]  && declare -r txStandout=$(tput smso)    && export txStandout    # standout
-[ -z $txEndStand ]  && declare -r txEndStand=$(tput rmso)    && export txEndStand    # exit standout
-[ -z $txReset ]     && declare -r txReset=$(tput sgr0)       && export txReset       # reset attributes
+(( ${+txBold} ))      || { txBold=$(tput bold)        && declare -rx txBold }      # bold
+(( ${+txHalf} ))      || { txHalf=$(tput dim)         && declare -rx txHalf }      # half-bright
+(( ${+txUnderline} )) || { txUnderline=$(tput smul)   && declare -rx txUnderline } # underline
+(( ${+txEndUnder} ))  || { txEndUnder=$(tput rmul)    && declare -rx txEndUnder }  # exit underline
+(( ${+txReverse} ))   || { txReverse=$(tput rev)      && declare -rx txReverse }   # reverse
+(( ${+txStandout} ))  || { txStandout=$(tput smso)    && declare -rx txStandout }  # standout
+(( ${+txEndStand} ))  || { txEndStand=$(tput rmso)    && declare -rx txEndStand }  # exit standout
+(( ${+txReset} ))     || { txReset=$(tput sgr0)       && declare -rx txReset }     # reset attributes

--- a/vim/configure.sh
+++ b/vim/configure.sh
@@ -26,18 +26,40 @@ if [ "${INSTALL_MODE}" = 'full' ]; then
   )
 
   # clone vim plugins and pin them to their commit hash
+  plugin_names=()
   for entry in "${vim_plugins[@]}"; do
     repo="${entry% *}"
     commit="${entry#* }"
-    plugin_dir="${HOME}/.vim/bundle/$(basename "$repo" .git)"
+    plugin_name="$(basename "$repo" .git)"
+    plugin_dir="${HOME}/.vim/bundle/${plugin_name}"
+    plugin_names+=("$plugin_name")
 
     if [ -d "$plugin_dir" ]; then
-      echo "Updating $(basename "$repo" .git)"
+      echo "Updating $plugin_name"
       git -C "$plugin_dir" fetch --quiet --tags origin
     else
-      echo "Installing $(basename "$repo" .git)"
+      echo "Installing $plugin_name"
       git clone --quiet "$repo" "$plugin_dir"
     fi
     git -C "$plugin_dir" checkout --quiet "$commit"
+  done
+
+  # remove any previously installed plugins that are no longer listed above
+  for plugin_dir in "${HOME}/.vim/bundle"/*; do
+    [ -d "$plugin_dir" ] || continue
+    plugin_name="$(basename "$plugin_dir")"
+
+    keep=false
+    for name in "${plugin_names[@]}"; do
+      if [ "$name" = "$plugin_name" ]; then
+        keep=true
+        break
+      fi
+    done
+
+    if [ "$keep" = false ]; then
+      echo "Removing $plugin_name"
+      rm -rf "$plugin_dir"
+    fi
   done
 fi

--- a/vim/configure.sh
+++ b/vim/configure.sh
@@ -6,31 +6,38 @@ if [ "${INSTALL_MODE}" = 'full' ]; then
   mkdir -p "${HOME}/.vim/autoload" "${HOME}/.vim/bundle" "${HOME}/.vim/ftdetect"
   ln -sf "${DOTFILES_LOCATION}/vim/vimrc" "${HOME}/.vimrc"
 
-  # install vim pathogen
-  curl -fLSso "${HOME}/.vim/autoload/pathogen.vim" https://raw.githubusercontent.com/tpope/vim-pathogen/master/autoload/pathogen.vim
+  # install vim pathogen, pinned to a commit hash (latest release: v2.4) to reduce supply chain risk
+  pathogen_commit='4d584ea8c85408ca0d68b7b1693f3e2db8aa762a'
+  curl -fLSso "${HOME}/.vim/autoload/pathogen.vim" "https://raw.githubusercontent.com/tpope/vim-pathogen/${pathogen_commit}/autoload/pathogen.vim"
 
-  # array of vim plugins to be cloned
+  # vim plugins to be cloned, each pinned to a commit hash (latest release, or HEAD
+  # if the repo has none) to reduce supply chain risk from a compromised upstream branch
   vim_plugins=( \
-    'https://github.com/altercation/vim-colors-solarized.git' \
-    'https://github.com/ctrlpvim/ctrlp.vim.git' \
-    'https://github.com/godlygeek/tabular.git' \
-    'https://github.com/myusuf3/numbers.vim.git' \
-    'https://github.com/scrooloose/nerdtree.git' \
-    'https://github.com/sheerun/vim-polyglot.git' \
-    'https://github.com/tomtom/tlib_vim.git' \
-    'https://github.com/tpope/vim-surround.git' \
-    'https://github.com/vim-airline/vim-airline.git' \
-    'https://github.com/vim-airline/vim-airline-themes.git' \
+    'https://github.com/altercation/vim-colors-solarized.git 528a59f26d12278698bb946f8fb82a63711eec21' \
+    'https://github.com/ctrlpvim/ctrlp.vim.git 971c4d41880b72dbbf1620b3ad91418a6a6f6b9c' \
+    'https://github.com/godlygeek/tabular.git 7bd1d0de5d390834220b7d0a791bb9734fafa0cc' \
+    'https://github.com/myusuf3/numbers.vim.git d1e9dace93a628f22f159254f3754b5041f5602a' \
+    'https://github.com/scrooloose/nerdtree.git 9b465acb2745beb988eff3c1e4aa75f349738230' \
+    'https://github.com/sheerun/vim-polyglot.git 1d1f36b24ea601eb950865982e05b875aa702330' \
+    'https://github.com/tomtom/tlib_vim.git 2ae171a8eb6bbd65bdbf75cdb5fa5303d6483bba' \
+    'https://github.com/tpope/vim-surround.git aeb933272e72617f7c4d35e1f003be16836b948d' \
+    'https://github.com/vim-airline/vim-airline.git 1586662296c9dc946083e17cb6a4ef0b3e7c0d68' \
+    'https://github.com/vim-airline/vim-airline-themes.git 77aab8c6cf7179ddb8a05741da7e358a86b2c3ab' \
   )
 
-  # clone vim plugins
-  for repo in "${vim_plugins[@]}"; do
-    if [ -d "${HOME}/.vim/bundle/$(basename "$repo" .git)" ]; then
+  # clone vim plugins and pin them to their commit hash
+  for entry in "${vim_plugins[@]}"; do
+    repo="${entry% *}"
+    commit="${entry#* }"
+    plugin_dir="${HOME}/.vim/bundle/$(basename "$repo" .git)"
+
+    if [ -d "$plugin_dir" ]; then
       echo "Updating $(basename "$repo" .git)"
-      git -C "${HOME}/.vim/bundle/$(basename "$repo" .git)" pull --quiet
+      git -C "$plugin_dir" fetch --quiet --tags origin
     else
       echo "Installing $(basename "$repo" .git)"
-      git -C "${HOME}/.vim/bundle" clone --quiet "$repo"
+      git clone --quiet "$repo" "$plugin_dir"
     fi
+    git -C "$plugin_dir" checkout --quiet "$commit"
   done
 fi

--- a/vim/configure.sh
+++ b/vim/configure.sh
@@ -13,13 +13,9 @@ if [ "${INSTALL_MODE}" = 'full' ]; then
   vim_plugins=( \
     'https://github.com/altercation/vim-colors-solarized.git' \
     'https://github.com/ctrlpvim/ctrlp.vim.git' \
-    'https://github.com/garbas/vim-snipmate.git' \
     'https://github.com/godlygeek/tabular.git' \
-    'https://github.com/MarcWeber/vim-addon-mw-utils.git' \
     'https://github.com/myusuf3/numbers.vim.git' \
-    'https://github.com/rodjek/vim-puppet.git' \
     'https://github.com/scrooloose/nerdtree.git' \
-    'https://github.com/scrooloose/syntastic.git' \
     'https://github.com/sheerun/vim-polyglot.git' \
     'https://github.com/tomtom/tlib_vim.git' \
     'https://github.com/tpope/vim-surround.git' \

--- a/vim/configure.sh
+++ b/vim/configure.sh
@@ -3,14 +3,11 @@
 set -e
 
 if [ "${INSTALL_MODE}" = 'full' ]; then
-  test -d ${HOME}/.vim || mkdir ${HOME}/.vim
-  test -d ${HOME}/.vim/autoload || mkdir ${HOME}/.vim/autoload
-  test -d ${HOME}/.vim/bundle || mkdir ${HOME}/.vim/bundle
-  test -d ${HOME}/.vim/ftdetect || mkdir ${HOME}/.vim/ftdetect
+  mkdir -p "${HOME}/.vim/autoload" "${HOME}/.vim/bundle" "${HOME}/.vim/ftdetect"
   ln -sf "${DOTFILES_LOCATION}/vim/vimrc" "${HOME}/.vimrc"
 
   # install vim pathogen
-  curl -LSso ~/.vim/autoload/pathogen.vim https://raw.githubusercontent.com/tpope/vim-pathogen/master/autoload/pathogen.vim
+  curl -fLSso "${HOME}/.vim/autoload/pathogen.vim" https://raw.githubusercontent.com/tpope/vim-pathogen/master/autoload/pathogen.vim
 
   # array of vim plugins to be cloned
   vim_plugins=( \
@@ -32,12 +29,12 @@ if [ "${INSTALL_MODE}" = 'full' ]; then
 
   # clone vim plugins
   for repo in "${vim_plugins[@]}"; do
-    if [ -d "${HOME}/.vim/bundle/$(basename $repo .git)" ]; then
-      echo "Updating $(basename $repo .git)"
-      git -C "${HOME}/.vim/bundle/$(basename $repo .git)" pull --quiet
+    if [ -d "${HOME}/.vim/bundle/$(basename "$repo" .git)" ]; then
+      echo "Updating $(basename "$repo" .git)"
+      git -C "${HOME}/.vim/bundle/$(basename "$repo" .git)" pull --quiet
     else
-      echo "Installing $(basename $repo .git)"
-      git -C "${HOME}/.vim/bundle" clone --quiet $repo
+      echo "Installing $(basename "$repo" .git)"
+      git -C "${HOME}/.vim/bundle" clone --quiet "$repo"
     fi
   done
 fi

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -16,16 +16,8 @@ nnoremap <F5> :previous<CR>
 nnoremap <F6> :next<CR>
 
 set statusline+=%#warningmsg#
-set statusline+=%{SyntasticStatuslineFlag()}
 set statusline+=%*
 
-let g:syntastic_always_populate_loc_list = 1
-let g:syntastic_auto_loc_list = 1
-let g:syntastic_check_on_open = 1
-let g:syntastic_check_on_wq = 1
-let g:syntastic_enable_signs=1
-let g:syntastic_puppet_checkers=['puppet', 'puppetlint']
-let g:syntastic_puppet_puppetlint_args=" --no-class_inherits_from_params_class-check --no-relative_classname_inclusion --no-140chars-check"
 let mapleader=','
   "if exists(":Tabularize")
     nmap <Leader>a= :Tabularize /=<CR>
@@ -51,16 +43,6 @@ let g:enable_numbers = 0
 let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree' ,'ctrlp']
 nnoremap <F3> :NumbersToggle<CR>
 "NUMBERS END
-
-"VIMWIKI
-let g:vimwiki_list = [{'path': '/mnt/WORK/vimwiki/', 'syntax': 'markdown', 'ext': '.md'}]
-set nocompatible
-filetype plugin on
-"VIMWIKI END
-
-"SNIPMATE
-let g:snipMate = { 'snippet_version' : 1 }
-"SNIPMATE END
 
 " Append modeline after last line in buffer.
 " Use substitute() instead of printf() to handle '%%s' modeline in LaTeX

--- a/zsh/configure.sh
+++ b/zsh/configure.sh
@@ -2,7 +2,29 @@
 
 set -e
 
-$elevate chsh -s /usr/bin/zsh $(whoami)
+user=$(whoami)
+
+# get users current shell directly from /etc/passwd (avoids depending on getent,
+# which is missing on some minimal images) and stays consistent with the
+# /etc/passwd check used below to decide whether to run chsh
+current_shell=$(basename "$(grep "^$user:" /etc/passwd | cut -d: -f7)")
+if [ "$current_shell" = "$(basename "$(command -v zsh)")" ]; then
+  echo "Login shell is already zsh, skipping chsh"
+else
+  # chsh is missing on minimal RHEL-family images (util-linux-user) and pointless in containers
+  if command -v chsh &> /dev/null; then
+    # skip chsh if the current user is not in /etc/passwd (e.g. ldap user)
+    if grep -q "^$user:" /etc/passwd; then
+      echo "Changing login shell to zsh for user $user"
+      # shellcheck disable=SC2086,SC2154  # $elevate is exported by install.sh and must word-split
+      $elevate chsh -s "$(command -v zsh)" "$user" || echo "⚠️ unable to change login shell to zsh"
+    else
+      echo "⚠️ user $user not found in /etc/passwd, skipping login shell change"
+    fi
+  else
+    echo "⚠️ chsh not available, skipping login shell change"
+  fi
+fi
 
 cat <<'PROFILE' > "${HOME}/.profile"
 # override shell assignment


### PR DESCRIPTION
Hardens installation, download, and shell helper paths across the repo so bootstrap runs are safer and more portable. It also adds PR lint and install smoke coverage, ships `depflow` completion, and tightens Vim plugin management.

# Changes

## Feature
- vim: pin bundle plugins to specific SHAs and prune bundles that are no longer listed during configure runs

## Fix
- harden package installs and downloads by removing unauthenticated apt installs, verifying `getRelease` archives, failing fast on curl errors, and skipping `chsh` where it is unavailable or inappropriate
- omz: harden install and configure scripts, tolerate non-fatal plugin update failures, and manage custom symlinks/directories more defensively
- omz: fix helper portability issues, including `fd` fallback in `cdr`, `getent` hostname resolution, checksum-verified `kubectl` downloads, and safer command log paths
- omz: add zsh completion for `depflow`
- omz: export terminal color variables after assignment so readonly exports initialize correctly
- omz: replace the unescaped glob in `ip4`
- fzf: guard worktree switching against failed directory changes
- vim: remove deprecated plugins and drop obsolete `vimrc` settings
- git: ignore `.claude/settings.local.json` globally

## Docs
- omz: sync the README with current functions, completions, and documented sharp edges

## CI
- add shellcheck and zsh syntax linting through pre-commit on pull requests
- add containerized install smoke tests for pull requests across Ubuntu, Rocky Linux, and openSUSE