### PR TITLE
Add a searchable shell cheatsheet with drift checks

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -9,5 +9,5 @@ commitizen:
   template: .cz.changelog.md.j2
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 3.8.1
+  version: 3.9.0
   version_scheme: semver

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,12 @@ repos:
         language: system
         entry: bin/zsh_syntax_check
         files: ^(omz/(functions|completions)/[^/]+|omz/zshrc|omz/(install|configure)\.sh|.*\.zsh)$
+      - id: cheatsheet-audit
+        name: cheatsheet drift check
+        # `cheat` builds itself from function docstrings and alias comments, so
+        # a missing one silently drops the entry; README.md restates the same
+        # data by hand. This fails the commit instead of letting either rot.
+        language: system
+        entry: bin/cheatsheet_audit
+        pass_filenames: false
+        files: ^(omz/(aliases\.zsh|README\.md|functions/[^/]+)|fzf/[^/]+\.zsh)$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,12 +11,19 @@
         "statusBar.background": "#007fff",
         "statusBar.foreground": "#e7e7e7",
         "statusBarItem.hoverBackground": "#3399ff",
-        "statusBarItem.remoteBackground": "#007fff",
+        "statusBarItem.remoteBackground": "#ff9fcf",
         "statusBarItem.remoteForeground": "#e7e7e7",
         "titleBar.activeBackground": "#007fff",
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#007fff99",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "activityBarTop.activeBackground": "#3399ff",
+        "activityBarTop.background": "#3399ff",
+        "activityBarTop.foreground": "#15202b",
+        "activityBarTop.inactiveForeground": "#15202b99",
+        "commandCenter.foreground": "#e7e7e7",
+        "statusBar.debuggingBackground": "#007fff",
+        "statusBar.debuggingForeground": "#e7e7e7"
     },
     "peacock.color": "#007fff"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v3.9.0 (2026-07-26)
+
+### Feature
+
+- **omz**: add cheat, a searchable shortcut reference
+
+### Fix
+
+- **omz**: add completions for functions that lacked them
+- **fzf**: move git helpers into functions and repair gaf
+- **tmux**: preserve working directory when splitting panes
+- **fzf**: improve git picker bindings and layout
+
+### Refactor
+
+- **omz**: normalize docstring headers and document every alias
+
 ## v3.8.1 (2026-07-05)
 
 ### Fix

--- a/bin/cheatsheet_audit
+++ b/bin/cheatsheet_audit
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Report drift between the shell config and the documentation that describes it.
+#
+# `cheat` derives its dataset from the docstring header of each functions/ file
+# and the comment above each alias in aliases.zsh, so an entry that is missing
+# one of those silently disappears from the cheatsheet. README.md restates the
+# same information by hand and drifts the same way. This checks all of it.
+#
+# Usage: cheatsheet_audit [REPO_ROOT]
+set -uo pipefail
+
+repo="${1:-}"
+if [[ -z "$repo" ]]; then
+  repo="$(git rev-parse --show-toplevel 2>/dev/null)" || repo="$PWD"
+fi
+
+functions_dir="$repo/omz/functions"
+aliases_file="$repo/omz/aliases.zsh"
+readme="$repo/omz/README.md"
+
+for required in "$functions_dir" "$aliases_file" "$readme"; do
+  if [[ ! -e "$required" ]]; then
+    echo "🔴 cheatsheet_audit: not a dotfiles checkout: missing $required" >&2
+    exit 2
+  fi
+done
+
+issues=0
+report() {
+  # report <heading> <line>...  — mapfile yields a single empty element for
+  # empty input, so drop blanks before deciding whether there is anything here.
+  local heading="$1"; shift
+  local -a lines=()
+  local line
+  for line in "$@"; do
+    [[ -n "${line// /}" ]] && lines+=("$line")
+  done
+  (( ${#lines[@]} )) || return 0
+  echo "⚠ $heading"
+  printf '    %s\n' "${lines[@]}"
+  issues=$(( issues + ${#lines[@]} ))
+}
+
+# --- 1. Function docstring headers ------------------------------------------
+# _cheat_data keys on "# <name> - <description>" as line 2, with the name
+# matching the filename.
+mapfile -t bad_headers < <(
+  for f in "$functions_dir"/*; do
+    [[ -f "$f" ]] || continue
+    base="${f##*/}"
+    [[ "$base" == _* ]] && continue
+    header="$(sed -n '2p' "$f")"
+    if [[ ! "$header" =~ ^\#\ ([A-Za-z_][A-Za-z0-9_]*)\ -\ .+$ ]]; then
+      echo "functions/$base — line 2 is not '# $base - <description>'"
+    elif [[ "${BASH_REMATCH[1]}" != "$base" ]]; then
+      echo "functions/$base — header names '${BASH_REMATCH[1]}', not '$base'"
+    fi
+  done
+)
+report "functions missing a parseable docstring header:" "${bad_headers[@]}"
+
+# --- 2. Alias descriptions ---------------------------------------------------
+# The comment directly above each alias is its description. A section header of
+# the form "# <topic> stuff" does not count.
+mapfile -t undocumented_aliases < <(
+  awk '
+    /^# [A-Za-z0-9]+ stuff$/ { prev = ""; next }
+    /^alias / {
+      name = $0; sub(/^alias /, "", name); sub(/=.*/, "", name)
+      if (prev !~ /^# /) print "alias " name " — no description comment above it"
+      prev = ""; next
+    }
+    { prev = $0 }
+  ' "$aliases_file"
+)
+report "aliases missing a description comment:" "${undocumented_aliases[@]}"
+
+# --- 3. README function list vs reality --------------------------------------
+# Two different readings of the same section, because the two directions need
+# opposite biases. "Is it documented?" counts any backticked name, so the fp
+# bullet covers the whole fp* family. "Is it stale?" counts only bullet heads,
+# so prose mentions like `cd` or `install` are not mistaken for entries.
+# shellcheck disable=SC2016  # backticks here are literal markdown, not a subshell
+readme_section="$(sed -n '/^#### `functions\/`/,/^#### /p' "$readme")"
+# shellcheck disable=SC2016
+mapfile -t readme_names < <(
+  grep -o '`[A-Za-z_][A-Za-z0-9_]*`' <<<"$readme_section" |
+    tr -d '`' | sort -u
+)
+# shellcheck disable=SC2016
+mapfile -t readme_entries < <(
+  sed -nE 's/^- \*\*`([A-Za-z_][A-Za-z0-9_]*)`\*\*.*/\1/p' <<<"$readme_section" | sort -u
+)
+mapfile -t actual_names < <(
+  for f in "$functions_dir"/*; do
+    [[ -f "$f" ]] || continue
+    base="${f##*/}"
+    [[ "$base" == _* ]] && continue
+    echo "$base"
+  done | sort -u
+)
+
+mapfile -t missing_from_readme < <(
+  comm -23 <(printf '%s\n' "${actual_names[@]}") <(printf '%s\n' "${readme_names[@]}")
+)
+report "functions defined but absent from README.md:" "${missing_from_readme[@]}"
+
+mapfile -t stale_in_readme < <(
+  comm -13 <(printf '%s\n' "${actual_names[@]}") <(printf '%s\n' "${readme_entries[@]}")
+)
+report "named in README.md but no longer defined in functions/:" "${stale_in_readme[@]}"
+
+# --- 4. User commands defined outside functions/ -----------------------------
+# This is the class that lost gcof/gaf/gswt: real commands living in a sourced
+# .zsh file, so nothing autoloads, completes, or documents them.
+mapfile -t stray_functions < <(
+  for f in "$repo"/omz/*.zsh "$repo"/fzf/*.zsh; do
+    [[ -f "$f" ]] || continue
+    grep -oE '^[[:space:]]*[A-Za-z][A-Za-z0-9_-]*\(\)[[:space:]]*\{' "$f" |
+      tr -d ' \t(){}' |
+      while read -r fn; do
+        [[ -n "$fn" ]] || continue
+        echo "${f#"$repo"/}: $fn() — belongs in omz/functions/"
+      done
+  done
+)
+report "shell functions defined outside omz/functions/:" "${stray_functions[@]}"
+
+# --- 5. README kubernetes alias table vs reality -----------------------------
+readme_table="$(sed -n '/^#### Kubernetes Aliases/,/^### /p' "$readme")"
+# shellcheck disable=SC2016  # backticks here are literal markdown, not a subshell
+mapfile -t table_aliases < <(
+  grep -oE '^\| `[a-z0-9]+`' <<<"$readme_table" | tr -d '| `' | sort -u
+)
+mapfile -t actual_k8s < <(
+  grep -oE '^alias k8[a-z]*' "$aliases_file" | sed 's/^alias //' | sort -u
+)
+mapfile -t k8s_drift < <(
+  comm -3 <(printf '%s\n' "${actual_k8s[@]}") <(printf '%s\n' "${table_aliases[@]}") |
+    sed -e 's/^\t/README table only: /' -e 's/^\([^ ]\)/defined but not in README table: \1/'
+)
+report "kubernetes alias table drift:" "${k8s_drift[@]}"
+
+# --- verdict -----------------------------------------------------------------
+if (( issues )); then
+  echo
+  echo "🔴 cheatsheet_audit: $issues issue(s)"
+  exit 1
+fi
+
+echo "✅ cheatsheet_audit: config and docs agree"

--- a/fzf/fzf-git.sh
+++ b/fzf/fzf-git.sh
@@ -81,8 +81,8 @@ if [[ $1 == --list ]]; then
         branches -a
         ;;
       hashes)
-        echo 'CTRL-O (open in browser) ╱ CTRL-D (diff)'
-        echo 'CTRL-S (toggle sort) ╱ ALT-F (list files) ╱ ALT-A (show all hashes)'
+        echo 'CTRL-O (open in browser) ╱ CTRL-D (diff) ╱ CTRL-S (toggle sort)'
+        echo 'ALT-R (toggle raw mode) ╱ ALT-F (list files) ╱ ALT-A (show all hashes)'
         hashes
         ;;
       all-hashes)
@@ -95,7 +95,7 @@ if [[ $1 == --list ]]; then
         refs --exclude='refs/remotes'
         ;;
       all-refs)
-        echo 'CTRL-O (open in browser) ╱ ALT-E (examine in editor)'
+        echo 'CTRL-O (open in browser) ╱ ALT-E (examine in editor) ╱ ALT-ENTER (accept without remote)'
         refs
         ;;
       *) exit 1 ;;
@@ -173,7 +173,7 @@ else
   # Redefine this function to change the options
   _fzf_git_fzf() {
     fzf --height 50% --tmux 90%,70% \
-      --layout reverse --multi --min-height 20+ --border \
+      --layout reverse --multi --min-height 20+ \
       --no-separator --header-border horizontal \
       --border-label-pos 2 \
       --color 'label:blue' \
@@ -265,13 +265,14 @@ _fzf_git_tags() {
     --border-label '📛 Tags ' \
     --header 'CTRL-O (open in browser)' \
     --bind "ctrl-o:execute-silent:bash \"$__fzf_git\" --list tag {}" \
+    --bind 'alt-r:toggle-raw' \
     --preview "git show --color=$(__fzf_git_color .) {} | $(__fzf_git_pager)" "$@"
 }
 
 _fzf_git_hashes() {
   _fzf_git_check || return
   bash "$__fzf_git" --list hashes |
-  _fzf_git_fzf --ansi --no-sort --bind 'ctrl-s:toggle-sort' \
+  _fzf_git_fzf --ansi --no-sort --bind 'ctrl-s:toggle-sort,alt-r:toggle-raw' \
     --border-label '🍡 Hashes ' \
     --header-lines 2 \
     --bind "ctrl-o:execute-silent:bash \"$__fzf_git\" --list commit {}" \
@@ -325,6 +326,7 @@ _fzf_git_lreflogs() {
   _fzf_git_check || return
   git reflog --color=$(__fzf_git_color) --format="%C(blue)%gD %C(yellow)%h%C(auto)%d %gs" | _fzf_git_fzf --ansi \
     --border-label '📒 Reflogs ' \
+    --bind 'alt-r:toggle-raw' \
     --preview "git show --color=$(__fzf_git_color .) {1} | $(__fzf_git_pager)" "$@" |
   awk '{print $1}'
 }
@@ -343,8 +345,10 @@ _fzf_git_each_ref() {
     --bind "ctrl-o:execute-silent:bash \"$__fzf_git\" --list {1} {2}" \
     --bind "alt-e:execute:${EDITOR:-vim} <(git show {2}) < /dev/tty > /dev/tty" \
     --bind "alt-a:change-border-label(🍀 Every ref)+reload:bash \"$__fzf_git\" --list all-refs" \
-    --preview "git log --oneline --graph --date=short --color=$(__fzf_git_color .) --pretty='format:%C(auto)%cd %h%d %s' {2} --" "$@" |
-  awk '{print $2}'
+    --bind "alt-enter:become:printf '%s\n' {+2} | sed 's@[^/]*/@@'" \
+    --preview "git log --oneline --graph --date=short --color=$(__fzf_git_color .) --pretty='format:%C(auto)%cd %h%d %s' {2} --" \
+    --accept-nth 2 \
+    "$@"
 }
 
 _fzf_git_worktrees() {

--- a/fzf/fzf.zsh
+++ b/fzf/fzf.zsh
@@ -21,15 +21,6 @@ if command -v fzf &> /dev/null; then
         --bind='ctrl-/:change-preview-window(down,50%,border-top|hidden|)' "$@"
   }
 
-  # git functions/aliases
-  gcof() {
-    _fzf_git_each_ref --no-multi | xargs git checkout
-  }
-
-  gaf() {
-    _fzf_git_each_files | xargs git add
-  }
-  gswt() {
-    cd "$(_fzf_git_worktrees --no-multi)" || return
-  }
+  # gcof, gaf, and gswt live in omz/functions/ alongside every other user
+  # command, so they are autoloaded, completed, and covered by `cheat`.
 fi

--- a/fzf/fzf.zsh
+++ b/fzf/fzf.zsh
@@ -1,7 +1,7 @@
 # if fzf is installed configure it
 if command -v fzf &> /dev/null; then
-  export FZF_DEFAULT_OPTS='--height 80% --tmux 95%,80% --layout reverse --border rounded'
-  export FZF_CTRL_T_OPTS='--preview-window="right,60%,border-left" --preview "bat --color=always --style=header,grid --line-range :500 {}"'
+  export FZF_DEFAULT_OPTS='--height 80% --tmux 100%,100% --layout reverse --border rounded'
+  export FZF_CTRL_T_OPTS='--preview-window="bottom,70%,border-top" --preview "bat --color=always --style=header,grid --line-range :500 {}"'
   export FZF_ALT_C_OPTS="--preview 'tree -C {} | head -200'"
   export FZF_CTRL_R_OPTS="--preview 'bat {}' --preview-window down:3:hidden:wrap --bind '?:toggle-preview'"
 
@@ -13,11 +13,11 @@ if command -v fzf &> /dev/null; then
 
   # override fzf git integration defaults
   _fzf_git_fzf() {
-    fzf --height=50% --tmux 95%,80% \
+    fzf --height=80% --tmux 100%,100% \
         --layout=reverse --multi --min-height=20 --border \
         --border-label-pos=2 \
         --color='header:italic:underline,label:blue' \
-        --preview-window='right,65%,border-left' \
+        --preview-window='bottom,70%,border-top' \
         --bind='ctrl-/:change-preview-window(down,50%,border-top|hidden|)' "$@"
   }
 

--- a/omz/README.md
+++ b/omz/README.md
@@ -2,6 +2,49 @@
 
 This directory contains the Zsh and Oh My Zsh configuration for the dotfiles repo.
 
+## Cheatsheet
+
+Press **`CTRL-G ?`** for a searchable picker covering every key binding, alias, and function
+here — plus the tmux bindings from `tmux/tmux.conf` and its plugins — with a preview pane
+showing full help for whichever entry is highlighted. Selecting a function or alias puts its
+name on the command line; key bindings are listed to be pressed, not inserted.
+
+Inside the picker: `ALT-A` folds in the ~330 aliases oh-my-zsh plugins provide, which are
+hidden by default so they do not bury this config's own entries. `SHIFT-↑/↓` scrolls the
+preview, `CTRL-/` resizes it, `CTRL-Y` copies the name.
+
+This replaces the binding list fzf-git installs on the same chord, which showed only the
+`CTRL-G` chords in a one-shot `zle -M` message area with no search and no detail. The other
+fzf-git chords are untouched.
+
+The same data is available as a static screen:
+
+```zsh
+cheat                 # everything, grouped and paged
+cheat git             # one category
+cheat tmux            # a category family: tmux, tmux-pane, tmux-tools, tmux-copy
+cheat fixup           # anything matching a term
+cheat --keys          # key bindings only, shell and tmux
+cheat --fzf           # the picker, same as CTRL-G ?
+cheat --audit         # report drift between this config and this README
+```
+
+Nothing is hand-maintained twice. `cheat` derives its entries from the sources that already
+exist:
+
+| Data | Source |
+| ---- | ------ |
+| Functions | The `# <name> - <description>` docstring header of each `functions/` file |
+| Aliases | The `# description` comment on the line above each alias in `aliases.zsh` |
+| Key bindings | A curated table in `functions/_cheat_data` — `bindkey -L` reports widget names, not meanings, and the in-picker bindings exist only inside `--header` strings in `fzf/fzf-git.sh` |
+| tmux bindings | The same curated table, transcribed from `tmux list-keys` against `tmux/tmux.conf` so the plugin bindings (pain-control, yank, logging, resurrect, fingers) are included, not just the eleven written by hand |
+
+Because of that, **a function without a conforming docstring header, or an alias without a
+comment above it, silently vanishes from the cheatsheet**. The `cheatsheet-audit` pre-commit
+hook (`bin/cheatsheet_audit`) fails the commit when that happens, and also when this README
+names a function that no longer exists, omits one that does, or when a user command is defined
+as a shell function in `omz/*.zsh` or `fzf/*.zsh` instead of `functions/`.
+
 ## Structure
 
 ### Core Configuration Files
@@ -36,6 +79,7 @@ Individual function files that are autoloaded on-demand. Each file contains a si
 
 - **`ccm`** - Generate a commit message for staged changes with the `copilot` CLI, then commit with it
 - **`cdr`** - Fuzzy-select a git repository under `~/gitrepos` and `cd` into it
+- **`cheat`** - Searchable reference for every key binding, alias, and function below (see [Cheatsheet](#cheatsheet))
 - **`copipe`** - Pipe stdin or a file to the `copilot` CLI with a prompt
 - **`countdown`** - Timer countdown utility
 - **`czbnt`** - `cz bump`, then strip the semver tag it leaves on HEAD
@@ -43,9 +87,11 @@ Individual function files that are autoloaded on-demand. Each file contains a si
 - **`decode_jwt`** - Decode JWT tokens
 - **`ff`** - Fuzzy-find a file and open it in `$EDITOR`
 - **`fp`** - Podman fzf helpers dispatcher (`fpe`, `fpse`, `fpa`, `fpsa`, `fps`, `fprm`, `fprmi`, `fpl`, `fpst`, `fprestart`); run `fp help` for details
+- **`gaf`** - Fuzzy-select changed files and `git add` them
 - **`gcfuh`** - Interactively create fixup commits targeting the commits that last touched the changed lines
 - **`gciaf`** - `git commit -a --fixup` for a commit
 - **`gcif`** - `git commit --fixup` for a commit
+- **`gcof`** - Fuzzy-select a ref and `git checkout` it
 - **`gdu`** - `git diff` with 0 lines of context
 - **`gdus`** - `git diff --cached` with 0 lines of context
 - **`get_k8s_images`** - Extract container images from Kubernetes pods with filtering and parsing options
@@ -55,6 +101,7 @@ Individual function files that are autoloaded on-demand. Each file contains a si
 - **`git_pr_check`** - Check subdirectories for GitHub pull requests
 - **`git_tag_semver`** - Semantically tag a git repository with major/minor/patch versions
 - **`grias`** - `git rebase --interactive --autosquash` from the branch base
+- **`gswt`** - Fuzzy-select a linked worktree and `cd` into it
 - **`gundo`** - Undo the last commit (soft reset, keeps changes staged)
 - **`install_it`** - Use Linux `install` to install binaries in `/usr/local/bin`
 - **`install_kubectl`** - Install or upgrade kubectl to a specific version (checksum-verified)
@@ -70,7 +117,12 @@ Individual function files that are autoloaded on-demand. Each file contains a si
 
 Zsh completion functions (prefixed with `_`) symlinked to `$ZSH_CUSTOM/completions/`.
 
-Hand-written completions for the custom functions above: `_ccm`, `_copipe`, `_czbnt`, `_decode_cert`, `_decode_jwt`, `_fp` (dispatcher), `_fpe` (also covers `fpse`), `_fpl`, `_fp_simple` (covers `fpa`, `fpsa`, `fps`, `fprm`, `fprmi`, `fpst`, `fprestart`), `_gcfuh`, `_gciaf`, `_gcif`, `_gdu`, `_gdus`, `_get_k8s_images`, `_ghist`, `_git_delete_head_semver_tags`, `_git_pr_check`, `_git_tag_semver`, `_grias`, `_install_it`, `_update_omz_all`, plus the shared helper `_commits_since_merge`.
+Functions that take no arguments (`cdr`, `ff`, `gaf`, `gcof`, `gswt`, `gundo`,
+`update_git_mirrors_in_subdirs`) share a single `_no_args` file, which suppresses the filename
+completion zsh would otherwise offer. `countdown` (an integer) and `rgf` (a free-form regex)
+have nothing worth completing and deliberately have no file.
+
+Hand-written completions for the custom functions above: `_ccm`, `_cheat`, `_copipe`, `_czbnt`, `_decode_cert`, `_decode_jwt`, `_fp` (dispatcher), `_fpe` (also covers `fpse`), `_fpl`, `_fp_simple` (covers `fpa`, `fpsa`, `fps`, `fprm`, `fprmi`, `fpst`, `fprestart`), `_gcfuh`, `_gciaf`, `_gcif`, `_gdu`, `_gdus`, `_get_k8s_images`, `_ghist`, `_git_delete_head_semver_tags`, `_git_find_branch_base`, `_git_pr_check`, `_git_tag_semver`, `_grias`, `_install_it`, `_install_kubectl`, `_joincsv`, `_log_cmd` (also covers `log_cmd_d`), `_pprint`, `_update_omz_all`, plus the shared helpers `_commits_since_merge` and `_no_args`.
 
 Generated/vendored completions: `_bat`, `_fd`, `_rg` (shipped by the upstream tools) and `_getRelease`, `_depflow`, `_dyff`, `_goDiffIt`, `_kustomize`, `_subnetCalc`, `_timeBuddy` (Cobra-generated for external CLIs).
 
@@ -92,5 +144,11 @@ A few commands are deliberately powerful — know what they do before running th
 ## Adding New Functions
 
 1. Create a new file in `functions/` with the function name
-2. Add completion file to `completions/` prefixed with `_`
-3. The function will be automatically available after reloading Zsh
+2. Give it a docstring header whose second line reads `# <name> - <one-line description>`;
+   this is what `cheat` and the audit hook read
+3. Add completion file to `completions/` prefixed with `_`, then re-run `configure.sh` to
+   symlink it (the `functions/` directory is a single symlink and needs no re-run)
+4. Add a bullet for it under [`functions/`](#functions) in this README
+5. The function will be automatically available after reloading Zsh
+
+Run `bin/cheatsheet_audit` to confirm steps 2 and 4 are satisfied; pre-commit runs it for you.

--- a/omz/aliases.zsh
+++ b/omz/aliases.zsh
@@ -1,30 +1,57 @@
+# general stuff
+# Short-form DNS lookup honoring the search domain
 alias digg='dig +short +search '
+# Long listing
 alias dir='ls -l'
+# 50 largest directories here, in MB, descending
 alias dutop='sudo du -m --max-depth=1 . | sort -nr | head -n50'
+# grep with color always enabled
 alias grep='grep --color=auto'
+# Join stdin lines into one pipe-delimited alternation
 alias grepify=' tr -s "\n" "|" | sed "s/|$//"'
+# Show shell history
 alias h='history'
+# IPv4 address per interface, loopback excluded, as a table
 alias ip4="command ip -o -4 a | grep -v ': lo' | sed 's/[0-9]\+\:\s*//;s/\// \//' | column -t"
+# List all, long, with type indicators
 alias l='ls -alF'
+# List all, long
 alias la='ls -la'
+# List all, long, oldest modified first
 alias lal='ls -altr'
+# List only directories
 alias ldir='ll -d */'
+# Long listing
 alias ll='ls -l'
+# Long listing (typo guard)
 alias ls-l='ls -l'
+# Colorized ls with type indicators
 alias ls='ls -F --color=auto'
+# Long listing, oldest modified first
 alias lt='ls -ltr'
+# Long listing, oldest accessed first
 alias lu='ls -ltur'
+# ls (typo guard)
 alias sl='ls'
+# ⚠ ssh with host key checking disabled
 alias sssh='ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+# ⚠ scp with host key checking disabled
 alias sscp='scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+# Convert whitespace-separated stdin into CSV
 alias toCSV="awk 'BEGIN { OFS=\",\" } { \$1=\$1; print }'"
+# tmux forced to 256 colors
 alias tmux='tmux -2'
+# git pull every plugin under ~/.vim/bundle
 alias update_vim_plugins='for dir in $(ls -1 ~/.vim/bundle); do echo "$dir"; git -C "$HOME/.vim/bundle/$dir" pull; echo; done'
 
 # date stuff
+# Today as YYYY-MM-DD
 alias d='date +%Y-%m-%d'
+# Now as YYYY-MM-DD-HH:MM
 alias dt='date +%Y-%m-%d-%H:%M'
+# Today as YYYYMMDD
 alias sd='date +%Y%m%d'
+# Now as YYYYMMDD-HHMM
 alias sdt='date +%Y%m%d-%H%M'
 
 # kubernetes stuff
@@ -94,10 +121,13 @@ alias k8tc='kubectl top pods -A --sort-by=cpu'
 alias k8tm='kubectl top pods -A --sort-by=memory'
 
 # git stuff
+# ⚠ Rebase every local branch onto the default branch and force-push each
 alias gitrebaseall='def_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed "s@^refs/remotes/origin/@@" || { git branch | grep -m1 -E "development|production|main|master" | tr -d " *"; }); for branch in $(git branch | grep -vE "development|production|main|master" | tr -d " *"); do echo "Rebasing $branch..."; git checkout $branch && git rebase $def_branch && git push origin $branch -f || { echo "❌ Failed on $branch"; git rebase --abort 2>/dev/null; git checkout $def_branch; return 1; }; echo;done; git checkout $def_branch; git branch -v'
 
 # zsh stuff
+# Open nvim
 alias n=nvim
 
 # bat stuff
+# bat with no decorations (plain output)
 alias batp='bat --plain'

--- a/omz/completions/_cheat
+++ b/omz/completions/_cheat
@@ -1,0 +1,45 @@
+#compdef cheat
+
+# Completion for "cheat" - searchable reference for keys, aliases, and functions.
+_cheat() {
+  local state line
+  typeset -A opt_args
+  local -a cats
+  cats=(
+    'keys:zsh and fzf key bindings'
+    'fzf-git:CTRL-G chords'
+    'picker:bindings inside an fzf-git picker'
+    'tmux:all tmux bindings (pane, tools, copy mode)'
+    'tmux-pane:tmux pane and window management'
+    'tmux-tools:tmux plugin features'
+    'tmux-copy:tmux copy mode'
+    'git:git functions and aliases'
+    'k8s:kubernetes aliases and helpers'
+    'podman:fp podman helpers'
+    'files:file finders and navigation'
+    'crypto:certificate and token decoders'
+    'ai:Copilot helpers'
+    'install:installers'
+    'date:date formats'
+    'general:general shell aliases'
+    'zsh:zsh and oh-my-zsh maintenance'
+    'bat:bat aliases'
+    'misc:everything else'
+  )
+
+  _arguments -s -S \
+    '(--fzf --keys --list --audit)--fzf[Open the interactive picker]' \
+    '(--fzf --keys --list --audit)--keys[Show key bindings only]' \
+    '(--fzf --keys --list --audit)--list[Emit the raw TSV dataset]' \
+    '(--fzf --keys --list --audit)--audit[Report drift against omz/README.md]' \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '1:category or search term:->term'
+
+  case "$state" in
+    term)
+      _describe -t categories 'category' cats
+      ;;
+  esac
+}
+
+_cheat "$@"

--- a/omz/completions/_git_find_branch_base
+++ b/omz/completions/_git_find_branch_base
@@ -1,0 +1,9 @@
+#compdef git_find_branch_base
+
+# Completion for "git_find_branch_base" - merge base commit, or branch name.
+_git_find_branch_base() {
+  _arguments -s -S \
+    '(-n --name)'{-n,--name}'[Return the branch name instead of the commit hash]'
+}
+
+_git_find_branch_base "$@"

--- a/omz/completions/_install_kubectl
+++ b/omz/completions/_install_kubectl
@@ -1,0 +1,23 @@
+#compdef install_kubectl
+
+# Completion for "install_kubectl" - install or upgrade kubectl.
+#
+# The version argument is deliberately not completed from the network: a
+# completion that blocks on an HTTP request makes TAB feel broken. A message
+# is shown instead so the expected format is obvious.
+_install_kubectl() {
+  local state line
+  typeset -A opt_args
+
+  _arguments -s -S \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '1:version:->version'
+
+  case "$state" in
+    version)
+      _message -r 'minor version to install, e.g. 1.34 (omit for latest)'
+      ;;
+  esac
+}
+
+_install_kubectl "$@"

--- a/omz/completions/_joincsv
+++ b/omz/completions/_joincsv
@@ -1,0 +1,11 @@
+#compdef joincsv
+
+# Completion for "joincsv" - join two CSV files on their first column.
+_joincsv() {
+  _arguments -s -S \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '1:first csv:_files -g "*.(csv|CSV)"' \
+    '2:second csv:_files -g "*.(csv|CSV)"'
+}
+
+_joincsv "$@"

--- a/omz/completions/_log_cmd
+++ b/omz/completions/_log_cmd
@@ -1,0 +1,19 @@
+#compdef log_cmd log_cmd_d
+
+# Completion for "log_cmd" and "log_cmd_d" - run a command with its output
+# logged to a file. Both wrap an arbitrary command, so complete a command name
+# in the first position and then hand off to that command's own completion,
+# the same way _sudo does.
+_log_cmd() {
+  if (( CURRENT == 2 )); then
+    _alternative \
+      'commands:command:_command_names -e' \
+      'options:option:((-h\:"Show help" --help\:"Show help"))'
+  else
+    shift words
+    (( CURRENT-- ))
+    _normal
+  fi
+}
+
+_log_cmd "$@"

--- a/omz/completions/_no_args
+++ b/omz/completions/_no_args
@@ -1,0 +1,14 @@
+#compdef cdr ff gaf gcof gswt gundo update_git_mirrors_in_subdirs
+
+# Completion for the functions that take no arguments at all.
+#
+# Without this, zsh falls back to completing filenames for them, which is
+# always wrong: each of these either picks its own target through fzf or
+# operates on the current repo. Follows the _fp_simple precedent of covering
+# several commands from one file.
+_no_args() {
+  _message -r 'no arguments'
+  return 1
+}
+
+_no_args "$@"

--- a/omz/completions/_pprint
+++ b/omz/completions/_pprint
@@ -1,0 +1,30 @@
+#compdef pprint
+
+# Completion for "pprint" - pretty print with color and text decorations.
+#
+# The style arguments are the fg*/bg*/tx* parameters from variables.zsh, of
+# which there are three dozen. They are read from the live shell rather than
+# hardcoded, so anything added to variables.zsh shows up here automatically.
+_pprint() {
+  local state line
+  typeset -A opt_args
+
+  _arguments -s \
+    '-n[Do not output the trailing newline]' \
+    '(-h --help)'{-h,--help}'[Show help]' \
+    '1:text to print:' \
+    '*:style:->styles'
+
+  case "$state" in
+    styles)
+      local -a styles
+      styles=( ${(k)parameters[(I)(fg|bg|tx)[A-Z]*]} )
+      (( ${#styles} )) || return 1
+      # Insert with the $ so the result is usable as-is: pprint "hi" $fgRed
+      styles=( ${styles/#/\$} )
+      _describe -t styles 'style' styles
+      ;;
+  esac
+}
+
+_pprint "$@"

--- a/omz/functions/_cheat_data
+++ b/omz/functions/_cheat_data
@@ -1,0 +1,191 @@
+#######################################
+# _cheat_data - Emit the cheatsheet dataset as tab-separated rows
+#
+# Three producers feed one stream: a curated key binding table (the only data
+# that cannot be derived, since `bindkey -L` yields widget names rather than
+# meanings), plus descriptions parsed out of the function docstrings and
+# aliases.zsh comments that the repo already maintains.
+#
+# Fields, tab separated:
+#   1 category  grouping key, e.g. keys, fzf-git, git, k8s
+#   2 kind      key | fn | ali
+#   3 name      chord, function name, or alias name
+#   4 summary   one line description, may start with "⚠" to flag a sharp edge
+#   5 source    where the preview pane should read detail from:
+#                 fn:<name>   docstring in $ZSH_CUSTOM/functions/<name>
+#                 ali:<name>  definition in $ZSH_CUSTOM/aliases.zsh
+#                 txt:<text>  literal text, \n escapes expanded by the reader
+#
+# Arguments:
+#   --all   also emit aliases provided by oh-my-zsh plugins (category "omz")
+# Outputs:
+#   TSV rows on stdout, unsorted
+# Returns:
+#   0 always
+#######################################
+emulate -L zsh
+setopt local_options no_nomatch
+
+local all=0
+[[ "$1" == "--all" ]] && all=1
+
+local zc="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+local aliases_file="$zc/aliases.zsh"
+local functions_dir="$zc/functions"
+
+# ---------------------------------------------------------------------------
+# 1. Curated key bindings.
+#
+# Sourced from omz/zshrc (^space), `fzf --zsh` (^t/^r/alt-c), and the chord
+# loop plus picker --header/--bind strings in fzf/fzf-git.sh.
+# ---------------------------------------------------------------------------
+local -a curated
+curated=(
+  $'keys\tkey\tCTRL-SPACE\tAccept and run the current autosuggestion\ttxt:Runs the greyed-out suggestion immediately, rather than\\njust accepting it onto the command line.\\n\\nBound in omz/zshrc as: bindkey \'^ \' autosuggest-execute'
+  $'keys\tkey\tCTRL-T\tfzf file picker, inserts the path\ttxt:Fuzzy-find a file anywhere below the current directory and\\ninsert its path at the cursor.\\n\\nPreview pane shows the file through bat.'
+  $'keys\tkey\tCTRL-R\tfzf history search\ttxt:Fuzzy-find a previous command and put it on the line.\\n\\n  ?  toggle the preview pane (hidden by default)'
+  $'keys\tkey\tALT-C\tfzf cd into a subdirectory\ttxt:Fuzzy-find a directory below the current one and cd into it.\\n\\nPreview pane shows the directory tree.'
+  $'keys\tkey\tCTRL-G ?\tThis cheatsheet\ttxt:Opens the searchable cheatsheet picker.\\n\\nReplaces the stock fzf-git binding list, which showed only the\\nCTRL-G chords in a cramped zle message area.'
+
+  $'fzf-git\tkey\tCTRL-G CTRL-F\tFiles - git status\ttxt:Pick from files git reports as changed or untracked.\\n\\n  CTRL-O  open in browser      ALT-E   open in editor\\n  CTRL-/  cycle preview        TAB     multi-select\\n\\nAlso bound without the second CTRL: CTRL-G f'
+  $'fzf-git\tkey\tCTRL-G CTRL-B\tBranches\ttxt:Pick from local branches.\\n\\n  CTRL-O     open in browser    ALT-A  show all branches\\n  ALT-ENTER  accept without the remote prefix\\n  CTRL-/     cycle preview     TAB    multi-select\\n\\nAlso bound without the second CTRL: CTRL-G b'
+  $'fzf-git\tkey\tCTRL-G CTRL-T\tTags\ttxt:Pick from tags.\\n\\n  CTRL-O  open in browser      ALT-R  toggle raw view\\n\\nAlso bound without the second CTRL: CTRL-G t'
+  $'fzf-git\tkey\tCTRL-G CTRL-R\tRemotes\ttxt:Pick from configured remotes.\\n\\n  CTRL-O  open in browser\\n\\nAlso bound without the second CTRL: CTRL-G r'
+  $'fzf-git\tkey\tCTRL-G CTRL-H\tCommit hashes\ttxt:Pick from the commit log.\\n\\n  CTRL-O  open in browser      CTRL-D  show diff\\n  CTRL-S  toggle sort          ALT-F   list files in commit\\n  ALT-R   toggle raw view\\n\\nAlso bound without the second CTRL: CTRL-G h'
+  $'fzf-git\tkey\tCTRL-G CTRL-S\tStashes\ttxt:Pick from the stash list.\\n\\n  CTRL-X  drop the selected stash  (destructive)\\n\\nAlso bound without the second CTRL: CTRL-G s'
+  $'fzf-git\tkey\tCTRL-G CTRL-L\tReflogs\ttxt:Pick from the reflog.\\n\\n  ALT-R  toggle raw view\\n\\nAlso bound without the second CTRL: CTRL-G l'
+  $'fzf-git\tkey\tCTRL-G CTRL-W\tWorktrees\ttxt:Pick from linked worktrees.\\n\\n  CTRL-X  remove the selected worktree  (destructive)\\n\\nSee also the gswt function, which cds into the choice.\\n\\nAlso bound without the second CTRL: CTRL-G w'
+  $'fzf-git\tkey\tCTRL-G CTRL-E\tEach ref - git for-each-ref\ttxt:Pick from every ref: branches, tags, remotes, HEAD.\\n\\n  CTRL-O     open in browser    ALT-E  examine in editor\\n  ALT-A      show all refs\\n  ALT-ENTER  accept without the remote prefix\\n\\nAlso bound without the second CTRL: CTRL-G e'
+
+  $'picker\tkey\tCTRL-O\tOpen the selection in your browser\ttxt:Available in every fzf-git picker. Opens the file, branch,\\ncommit, tag, or remote on its hosting site.'
+  $'picker\tkey\tALT-E\tOpen or examine the selection in $EDITOR\ttxt:Available in the files, tree, and each-ref pickers.'
+  $'picker\tkey\tCTRL-D\tShow the diff for the selection\ttxt:Available in the commit hashes picker.'
+  $'picker\tkey\tCTRL-S\tToggle sort\ttxt:Available in the commit hashes picker.'
+  $'picker\tkey\tALT-A\tShow all branches or all refs\ttxt:Widens branches to include remotes, and each-ref to include\\nevery ref rather than the common subset.'
+  $'picker\tkey\tALT-R\tToggle raw view\ttxt:Available in the tags, hashes, and reflog pickers. Swaps the\\nformatted columns for the underlying git output.'
+  $'picker\tkey\tALT-F\tList the files in the selected commit\ttxt:Available in the commit hashes picker.'
+  $'picker\tkey\tALT-ENTER\tAccept without the remote prefix\ttxt:In branches and each-ref, yields "main" rather than\\n"origin/main".'
+  $'picker\tkey\tCTRL-X\tDrop stash or remove worktree\ttxt:⚠ Destructive, and takes effect immediately without a\\nconfirmation prompt.'
+  $'picker\tkey\tCTRL-/\tCycle the preview window layout\ttxt:Rotates through down / hidden / default. Set for the fzf-git\\npickers by the _fzf_git_fzf override in fzf/fzf.zsh.'
+  $'picker\tkey\tTAB\tMulti-select\ttxt:fzf-git pickers run with --multi, so TAB marks several\\nentries and they are all inserted, space separated.'
+
+  $'tmux\tkey\tALT-←/→/↑/↓\tMove between panes, no prefix\ttxt:Bound in tmux/tmux.conf with `bind -n`, so no CTRL-B first.\\n\\nThe prefixed equivalents are CTRL-B h/j/k/l and CTRL-B arrows.'
+  $'tmux\tkey\tSHIFT-←/→\tPrevious / next window, no prefix\ttxt:Bound in tmux/tmux.conf with `bind -n`, so no CTRL-B first.\\n\\nThe prefixed equivalents are CTRL-B p and CTRL-B n.'
+
+  $'tmux-pane\tkey\tCTRL-B |\tSplit into left and right panes\ttxt:Keeps the current working directory.\\n\\nCTRL-B \\\\ does the same but spans the full window width.'
+  $'tmux-pane\tkey\tCTRL-B -\tSplit into top and bottom panes\ttxt:Keeps the current working directory.\\n\\nCTRL-B _ does the same but spans the full window height.'
+  $'tmux-pane\tkey\tCTRL-B +\tSplit into left and right panes\ttxt:A personal alias for CTRL-B |, bound in tmux/tmux.conf.\\nBoth keep the current working directory.'
+  $'tmux-pane\tkey\tCTRL-B h j k l\tMove between panes\ttxt:From tmux-pain-control. CTRL-B and an arrow key works too.'
+  $'tmux-pane\tkey\tCTRL-B H J K L\tResize the pane by 5 cells\ttxt:Repeatable: hold the shifted letter after one CTRL-B.\\n\\nCTRL-B ALT-arrow resizes as well.'
+  $'tmux-pane\tkey\tCTRL-B z\tZoom the pane full screen, toggle\ttxt:The single most useful tmux binding. Press again to restore\\nthe pane to its normal size.'
+  $'tmux-pane\tkey\tCTRL-B q\tShow pane numbers\ttxt:Type a number while they are displayed to jump to that pane.'
+  $'tmux-pane\tkey\tCTRL-B o\tCycle to the next pane\ttxt:Order follows pane index, not screen position.'
+  $'tmux-pane\tkey\tCTRL-B E\tSpread panes out evenly\ttxt:CTRL-B ALT-1 through ALT-7 pick a specific preset layout:\\n\\n  ALT-1 even-horizontal   ALT-5 tiled\\n  ALT-2 even-vertical     ALT-6 main-horizontal-mirrored\\n  ALT-3 main-horizontal   ALT-7 main-vertical-mirrored\\n  ALT-4 main-vertical'
+  $'tmux-pane\tkey\tCTRL-B < >\tMove this window left or right\ttxt:From tmux-pain-control. Repeatable.'
+  $'tmux-pane\tkey\tCTRL-B s\tPick a session from a tree\ttxt:CTRL-B w does the same for windows. Both open zoomed.'
+  $'tmux-pane\tkey\tCTRL-B f\tFind a window by name\ttxt:Searches window names and pane contents, then zooms to it.'
+  $'tmux-pane\tkey\tCTRL-B x\tKill this pane, with confirmation\ttxt:CTRL-B & kills the whole window, also with confirmation.'
+
+  $'tmux-tools\tkey\tCTRL-B X\tToggle synchronize-panes\ttxt:⚠ While on, every keystroke goes to EVERY pane in the window.\\nIntended for running the same command across several hosts.\\n\\nThe status line reports the new state when you toggle it.\\nTurn it off before typing anything destructive.'
+  $'tmux-tools\tkey\tCTRL-B F\tJump to any text on screen\ttxt:tmux-fingers. Overlays a short hint on every path, hash, URL,\\nIP, and number visible in the pane; type the hint to copy it.\\n\\nFaster than entering copy mode and selecting by hand.'
+  $'tmux-tools\tkey\tCTRL-B G\tJump the cursor to on-screen text\ttxt:tmux-fingers in jump mode. Same hints as CTRL-B F, but moves\\nthe cursor there instead of copying.'
+  $'tmux-tools\tkey\tCTRL-B y\tCopy the current command line\ttxt:tmux-yank. Copies what is typed at the prompt to the system\\nclipboard through wl-copy.'
+  $'tmux-tools\tkey\tCTRL-B Y\tCopy the pane working directory\ttxt:tmux-yank. Puts the pane cwd on the system clipboard.'
+  $'tmux-tools\tkey\tCTRL-B P\tToggle logging this pane to a file\ttxt:tmux-logging. Writes everything the pane prints to a file in\\nthe current directory until you press it again.'
+  $'tmux-tools\tkey\tCTRL-B ALT-p\tScreen capture the pane to a file\ttxt:tmux-logging. CTRL-B ALT-SHIFT-P instead saves the complete\\nscrollback history, not just the visible screen.'
+  $'tmux-tools\tkey\tCTRL-B ALT-c\tClear this pane\047s history\ttxt:tmux-logging. Drops the scrollback buffer for the pane.'
+  $'tmux-tools\tkey\tCTRL-B CTRL-S\tSave the whole tmux environment\ttxt:tmux-resurrect. Records every session, window, pane, layout,\\nand working directory.\\n\\nCTRL-B CTRL-R restores it, including after a reboot.'
+  $'tmux-tools\tkey\tCTRL-B I\tInstall plugins listed in tmux.conf\ttxt:tpm. CTRL-B U updates them, CTRL-B ALT-u removes any that are\\nno longer listed.'
+  $'tmux-tools\tkey\tCTRL-B ?\tList every tmux binding\ttxt:tmux\047s own binding list. Exhaustive but unsorted and unsearchable,\\nwhich is why the useful ones are curated here.'
+
+  $'tmux-copy\tkey\tCTRL-B [\tEnter copy mode\ttxt:Scroll back through pane history. Bindings are emacs style,\\nset by mode-keys in tmux/tmux.conf.\\n\\nCTRL-B ] pastes the buffer back.'
+  $'tmux-copy\tkey\ty\tCopy the selection, in copy mode\ttxt:tmux-yank, straight to the system clipboard via wl-copy.\\n\\nSelecting with the mouse copies automatically too.'
+  $'tmux-copy\tkey\tSHIFT-Y\tCopy and paste to the prompt\ttxt:In copy mode. Copies the selection and immediately pastes it\\nonto the command line.'
+  $'tmux-copy\tkey\t!\tCopy as a single line\ttxt:In copy mode. Strips newlines from the selection first, which\\nis what you want for a wrapped path or URL.'
+)
+printf '%s\n' "${curated[@]}"
+
+# ---------------------------------------------------------------------------
+# 2. Functions, from the "# <name> - <description>" docstring header line.
+# ---------------------------------------------------------------------------
+local f base name summary cat header
+for f in "$functions_dir"/*(.N); do
+  base="${f:t}"
+  [[ "$base" == _* ]] && continue
+
+  header="$(sed -n '2p' -- "$f")"
+  [[ "$header" == '# '*' - '* ]] || continue
+  name="${${header#\# }%% - *}"
+  summary="${header#*" - "}"
+
+  case "$name" in
+    get_k8s_images)                  cat=k8s ;;
+    fp|fp[a-z]*)                     cat=podman ;;
+    decode_*)                        cat=crypto ;;
+    install_*)                       cat=install ;;
+    copipe|ccm)                      cat=ai ;;
+    update_omz_all)                  cat=zsh ;;
+    cdr|ff|rgf)                      cat=files ;;
+    g*|czbnt|update_git_mirrors_in_subdirs) cat=git ;;
+    *)                               cat=misc ;;
+  esac
+
+  printf '%s\tfn\t%s\t%s\tfn:%s\n' "$cat" "$name" "$summary" "$name"
+done
+
+# ---------------------------------------------------------------------------
+# 3. Aliases, from the "# description" comment above each "alias name=" line.
+#
+# Section headers of the form "# <topic> stuff" set the category. Multi-line
+# aliases are safe: each still begins with "alias <name>=" on its own line, and
+# no continuation line starts with "# " or "alias ".
+# ---------------------------------------------------------------------------
+local -A owned
+if [[ -r "$aliases_file" ]]; then
+  local row
+  while IFS= read -r row; do
+    owned[${${row#*$'\t'*$'\t'}%%$'\t'*}]=1
+    print -r -- "$row"
+  done < <(
+    awk '
+      /^# [A-Za-z0-9]+ stuff$/ {
+        cat = $0; sub(/^# /, "", cat); sub(/ stuff$/, "", cat)
+        if (cat == "kubernetes") cat = "k8s"
+        desc = ""; next
+      }
+      /^# / { desc = $0; sub(/^# /, "", desc); next }
+      /^alias / {
+        name = $0; sub(/^alias /, "", name); sub(/=.*/, "", name)
+        if (desc != "")
+          printf "%s\tali\t%s\t%s\tali:%s\n", (cat == "" ? "misc" : cat), name, desc, name
+        desc = ""; next
+      }
+      { desc = "" }
+    ' "$aliases_file"
+  )
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Optional: aliases contributed by oh-my-zsh plugins. There is no
+#    description to be had for these, so the expansion stands in as the
+#    summary. Excluded from the static screen, which must stay glanceable.
+# ---------------------------------------------------------------------------
+if (( all )); then
+  local line n v
+  while IFS= read -r line; do
+    [[ "$line" == 'alias '* ]] || continue
+    line="${line#alias }"
+    # Skip the -g / -s / -- forms; only plain command aliases are useful here.
+    [[ "$line" == -* ]] && continue
+    n="${line%%=*}"
+    [[ "$n" =~ '^[A-Za-z_][A-Za-z0-9_.-]*$' ]] || continue
+    [[ -n "${owned[$n]}" ]] && continue
+    v="${line#*=}"
+    # alias -L quotes the body; unwrap it for a readable one-line summary.
+    [[ "$v" == \'*\' ]] && v="${${v#\'}%\'}"
+    v="${v//$'\t'/ }"
+    local vs="$v"
+    (( ${#vs} > 100 )) && vs="${vs[1,97]}..."
+    printf '%s\tali\t%s\t%s\ttxt:alias %s=%s\n' omz "$n" "$vs" "$n" "$v"
+  done < <(alias -L 2>/dev/null)
+fi

--- a/omz/functions/_cheat_fzf
+++ b/omz/functions/_cheat_fzf
@@ -1,0 +1,235 @@
+#######################################
+# _cheat_fzf - Interactive cheatsheet picker with a detail preview pane
+#
+# Reads cheatsheet TSV rows on stdin and runs them through fzf. The preview
+# pane cannot call back into autoloaded functions, because fzf spawns it in a
+# fresh shell where FPATH is not exported, so the dataset and a small POSIX
+# preview script are written to temp files and referenced by path.
+#
+# Selecting a function or alias prints its name on stdout, for the caller to
+# insert on the command line. Key bindings print nothing; you press them.
+#
+# Inputs:
+#   Cheatsheet TSV rows on stdin
+# Outputs:
+#   The selected name on stdout, or nothing
+# Returns:
+#   0 on selection, 1 if cancelled or fzf is unavailable
+#######################################
+emulate -L zsh
+setopt local_options no_nomatch
+
+if ! command -v fzf >/dev/null 2>&1; then
+  pprint "🔴 fzf is required, but not found." "$fgRed" >&2
+  return 1
+fi
+
+local zc="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+local functions_dir="$zc/functions"
+local aliases_file="$zc/aliases.zsh"
+
+local data_file preview_script toggle_script state_file own_file all_file
+data_file="$(mktemp -t cheat_data.XXXXXX)"       || return 1
+preview_script="$(mktemp -t cheat_preview.XXXXXX)" || return 1
+toggle_script="$(mktemp -t cheat_toggle.XXXXXX)" || return 1
+state_file="$(mktemp -t cheat_state.XXXXXX)"     || return 1
+own_file="$(mktemp -t cheat_own.XXXXXX)"         || return 1
+all_file="$(mktemp -t cheat_all.XXXXXX)"         || return 1
+trap "rm -f -- ${(q)data_file} ${(q)preview_script} ${(q)toggle_script} ${(q)state_file} ${(q)own_file} ${(q)all_file}" EXIT INT TERM
+
+# Indexed dataset: idx, category, kind, name, summary, source.
+local -a rows
+rows=("${(@f)$(cat)}")
+rows=("${(@)rows:#}")
+(( ${#rows} )) || { pprint "🔴 cheat: no entries to show." "$fgRed" >&2; return 1 }
+
+local i
+for i in {1..${#rows}}; do
+  print -r -- "${i}"$'\t'"${rows[$i]}"
+done > "$data_file"
+
+cat > "$preview_script" <<'PREVIEW'
+#!/bin/sh
+# Renders one cheatsheet row. Invoked by fzf in its own shell, so it may not
+# assume anything beyond POSIX sh and the paths handed to it.
+data=$1; fdir=$2; afile=$3; idx=$4
+
+row=$(awk -F'\t' -v i="$idx" '$1 == i { print; exit }' "$data")
+[ -n "$row" ] || exit 0
+
+kind=$(printf '%s\n'    "$row" | cut -f3)
+name=$(printf '%s\n'    "$row" | cut -f4)
+summary=$(printf '%s\n' "$row" | cut -f5)
+src=$(printf '%s\n'     "$row" | cut -f6-)
+
+printf '\033[1;36m%s\033[0m\n' "$name"
+case $summary in
+  '⚠'*) printf '\033[31m%s\033[0m\n\n' "$summary" ;;
+  *)    printf '%s\n\n' "$summary" ;;
+esac
+
+highlight() {
+  if command -v bat >/dev/null 2>&1; then
+    bat --color=always -l bash --style=plain --paging=never
+  else
+    cat
+  fi
+}
+
+rule() { printf '\033[2m%s\033[0m\n' "── $1 ──"; }
+
+case $src in
+  fn:*)
+    n=${src#fn:}
+    f="$fdir/$n"
+    [ -r "$f" ] || exit 0
+
+    # Prose from the docstring, past the "# <name> - <summary>" header line
+    # already shown above. Empty for the functions that keep their detail in a
+    # --help heredoc instead.
+    body=$(awk '
+      NR <= 2 { next }
+      /^#######/ { exit }
+      { sub(/^# ?/, ""); print }
+    ' "$f")
+    [ -n "$body" ] && printf '%s\n\n' "$body"
+
+    # Three help idioms are in use across functions/. Take the first that
+    # yields anything, and fall back to the source itself.
+    help=$(sed -n "/<<'EOF'/,/^EOF\$/p" "$f" | sed '1d;$d')
+
+    if [ -z "$help" ]; then
+      case $n in
+        fp?*)
+          help=$(awk -v n="$n" '
+            $0 == "  " n ")" { p = 1; next }
+            p && $0 == "    ;;" { exit }
+            p { print }
+          ' "$fdir/_fp_command_help" 2>/dev/null |
+            sed -e '/printf/d' \
+                -e 's/[[:space:]]*\\$//' \
+                -e "s/^[[:space:]]*'//" \
+                -e "s/'[[:space:]]*\$//")
+          ;;
+      esac
+    fi
+
+    if [ -n "$help" ]; then
+      rule "$n --help"
+      printf '%s\n' "$help"
+    else
+      rule "source"
+      sed -n '/^#######/,$p' "$f" | sed '1,/^#######/d' | head -n 60 | highlight
+    fi
+    ;;
+  ali:*)
+    n=${src#ali:}
+    [ -r "$afile" ] || exit 0
+    awk -v n="$n" '
+      index($0, "alias " n "=") == 1 { p = 1; print; next }
+      p && (index($0, "alias ") == 1 || index($0, "# ") == 1) { exit }
+      p { print }
+    ' "$afile" | highlight
+    ;;
+  txt:*)
+    printf '%b\n' "${src#txt:}"
+    ;;
+esac
+
+case $kind in
+  key) ;;
+  *) printf '\n\033[2m── enter inserts "%s" on the command line ──\033[0m\n' "$name" ;;
+esac
+PREVIEW
+chmod +x -- "$preview_script"
+
+# Parse once into parallel arrays: the name column width has to be known
+# before any display line can be formatted.
+local -a f_cat f_kind f_name f_summary
+local pad=0 cat kind name summary src
+for i in {1..${#rows}}; do
+  IFS=$'\t' read -r cat kind name summary src <<< "${rows[$i]}"
+  f_cat+=("$cat"); f_kind+=("$kind"); f_name+=("$name"); f_summary+=("$summary")
+  # omz plugin aliases are hidden by default, so they must not stretch the
+  # name column that the visible entries line up against.
+  if [[ "$cat" != omz ]] && (( ${#name} > pad )); then
+    pad=${#name}
+  fi
+done
+(( pad > 30 )) && pad=30
+
+# Fields: index, formatted display, raw name. --with-nth=2 shows only the
+# middle one; the raw name stays addressable as {3} for the copy binding.
+#
+# Two lists are written: this config alone, and that plus the oh-my-zsh plugin
+# aliases. The plugin aliases outnumber everything here roughly three to one,
+# so they stay behind ALT-A rather than burying the entries worth finding.
+local -a display
+local badge color line
+for i in {1..${#rows}}; do
+  case "${f_kind[$i]}" in
+    key) badge='key' color="${fgYellow:-}" ;;
+    fn)  badge='fn ' color="${fgGreen:-}" ;;
+    *)   badge='ali' color="${fgCyan:-}" ;;
+  esac
+  line="${i}"$'\t'"$(printf '%s%s%s %s%-*s%s %s' \
+    "${color}" "$badge" "${txReset:-}" \
+    "${txBold:-}" "$pad" "${f_name[$i]}" "${txReset:-}" \
+    "${f_summary[$i]}")"$'\t'"${f_name[$i]}"
+  display+=("$line")
+  [[ "${f_cat[$i]}" == omz ]] || print -r -- "$line" >> "$own_file"
+done
+print -rl -- "${display[@]}" > "$all_file"
+
+# ALT-A flips between the two lists. fzf's transform action lets the script
+# emit the actions to run, so the prompt can track the state as well.
+cat > "$toggle_script" <<'TOGGLE'
+#!/bin/sh
+state=$1; own=$2; all=$3
+if [ -s "$state" ]; then
+  : > "$state"
+  printf 'reload(cat %s)+change-prompt(cheat> )' "$own"
+else
+  echo on > "$state"
+  printf 'reload(cat %s)+change-prompt(cheat+omz> )' "$all"
+fi
+TOGGLE
+chmod +x -- "$toggle_script"
+
+local -a copy_bind
+if command -v wl-copy >/dev/null 2>&1; then
+  copy_bind=(--bind "ctrl-y:execute-silent(printf '%s' {3} | wl-copy)")
+elif command -v xclip >/dev/null 2>&1; then
+  copy_bind=(--bind "ctrl-y:execute-silent(printf '%s' {3} | xclip -selection clipboard)")
+fi
+
+local selected
+selected="$(
+  fzf --ansi \
+      --no-multi \
+      --delimiter=$'\t' \
+      --with-nth=2 \
+      --prompt='cheat> ' \
+      --border-label=' shortcuts ' \
+      --border-label-pos=2 \
+      --color='header:italic,label:blue' \
+      --header=$'enter insert  ·  ctrl-y copy  ·  alt-a omz aliases\nshift-↑↓ scroll preview  ·  ctrl-/ resize preview  ·  esc cancel' \
+      --preview="${(qq)preview_script} ${(qq)data_file} ${(qq)functions_dir} ${(qq)aliases_file} {1}" \
+      --preview-window='bottom,35%,border-top,wrap' \
+      --bind='ctrl-/:change-preview-window(bottom,70%,border-top|hidden|)' \
+      --bind='shift-up:preview-up,shift-down:preview-down' \
+      --bind='ctrl-u:preview-half-page-up,ctrl-d:preview-half-page-down' \
+      --bind="alt-a:transform:${(qq)toggle_script} ${(qq)state_file} ${(qq)own_file} ${(qq)all_file}" \
+      "${copy_bind[@]}" \
+      < "$own_file"
+)" || return 1
+
+[[ -n "$selected" ]] || return 1
+
+# Map the choice back to its row. Key bindings are not insertable.
+local idx="${selected%%$'\t'*}"
+local row="${rows[$idx]}"
+IFS=$'\t' read -r cat kind name summary _ <<< "$row"
+[[ "$kind" == key ]] && return 0
+
+print -r -- "$name"

--- a/omz/functions/_cheat_render
+++ b/omz/functions/_cheat_render
@@ -1,0 +1,105 @@
+#######################################
+# _cheat_render - Format cheatsheet TSV rows as a grouped static screen
+#
+# Reads the output of _cheat_data on stdin and prints it grouped by category,
+# in a fixed display order, with the name column right-sized per group. A
+# summary beginning with "⚠" is highlighted as a sharp edge.
+#
+# Arguments:
+#   --no-color   emit plain text, for pipes and redirects
+# Inputs:
+#   Cheatsheet TSV rows on stdin
+# Outputs:
+#   Formatted screen on stdout
+# Returns:
+#   0 always
+#######################################
+emulate -L zsh
+setopt local_options no_nomatch
+
+local color=1
+[[ "$1" == "--no-color" ]] && color=0
+
+local c_head c_name c_warn c_dim c_off
+if (( color )); then
+  c_head="${txBold}${fgCyan}"
+  c_name="${fgGreen}"
+  c_warn="${fgRed}"
+  c_dim="${fgGrey}"
+  c_off="${txReset}"
+fi
+
+# Display order and human labels. Categories not listed here still render,
+# appended in the order first seen, so a new one is never silently dropped.
+local -a order
+order=(
+  keys fzf-git picker
+  tmux tmux-pane tmux-tools tmux-copy
+  git k8s podman files crypto ai install date general zsh bat misc omz
+)
+local -A label
+label=(
+  keys       'Key bindings'
+  fzf-git    'fzf-git — CTRL-G prefix'
+  picker     'Inside an fzf-git picker'
+  tmux       'tmux — no prefix needed'
+  tmux-pane  'tmux panes & windows — CTRL-B prefix'
+  tmux-tools 'tmux tools — CTRL-B prefix'
+  tmux-copy  'tmux copy mode'
+  git      'Git'
+  k8s      'Kubernetes'
+  podman   'Podman — fp helpers'
+  files    'Files'
+  crypto   'Certificates & tokens'
+  ai       'Copilot'
+  install  'Install'
+  date     'Dates'
+  general  'General'
+  zsh      'Zsh'
+  bat      'bat'
+  misc     'Misc'
+  omz      'oh-my-zsh plugin aliases'
+)
+
+local -A rows
+local -a seen
+local cat kind name summary src
+while IFS=$'\t' read -r cat kind name summary src; do
+  [[ -n "$cat" ]] || continue
+  (( ${+rows[$cat]} )) || seen+=("$cat")
+  rows[$cat]+="${name}"$'\t'"${summary}"$'\n'
+done
+
+# Anything unexpected goes at the end rather than vanishing.
+local -a display
+display=(${(@)order:*seen} ${(@)seen:|order})
+
+local width=${COLUMNS:-80}
+(( width > 0 )) || width=80
+
+local entry n s pad first=1
+for cat in $display; do
+  (( ${+rows[$cat]} )) || continue
+
+  # Right-size the name column for this group only.
+  pad=0
+  for entry in ${(f)rows[$cat]}; do
+    n="${entry%%$'\t'*}"
+    (( ${#n} > pad )) && pad=${#n}
+  done
+  (( pad > 30 )) && pad=30
+
+  (( first )) || print
+  first=0
+  print -r -- "${c_head}${label[$cat]:-$cat}${c_off}"
+
+  for entry in ${(f)rows[$cat]}; do
+    n="${entry%%$'\t'*}"
+    s="${entry#*$'\t'}"
+    if [[ "$s" == '⚠'* ]]; then
+      printf '  %s%-*s%s  %s%s%s\n' "$c_name" "$pad" "$n" "$c_off" "$c_warn" "$s" "$c_off"
+    else
+      printf '  %s%-*s%s  %s\n' "$c_name" "$pad" "$n" "$c_off" "$s"
+    fi
+  done
+done

--- a/omz/functions/ccm
+++ b/omz/functions/ccm
@@ -1,5 +1,5 @@
 #######################################
-# ccm
+# ccm - Generate a Conventional Commit message from staged changes via Copilot
 #######################################
 setopt localoptions localtraps
 

--- a/omz/functions/cheat
+++ b/omz/functions/cheat
@@ -1,0 +1,133 @@
+#######################################
+# cheat - Searchable reference for this shell's keys, aliases, and functions
+#
+# With no arguments prints a grouped overview screen. Given a category or
+# search term, filters to it. With --fzf opens the interactive picker, which is
+# what CTRL-G ? is bound to.
+#
+# The data is derived from the shell config itself: function docstring headers,
+# aliases.zsh comments, and a curated key binding table in _cheat_data.
+#
+# Arguments:
+#   [TERM]       Filter to a category or match against names and summaries
+#   --fzf        Open the interactive picker instead of the static screen
+#   --keys       Key bindings only
+#   --list       Raw TSV, for scripting
+#   --audit      Report drift between the config and README.md
+#   -h, --help   Show this help
+# Outputs:
+#   Formatted reference on stdout, paged when the terminal is interactive
+# Returns:
+#   0 on success, 1 on an unknown option or a failed audit
+#######################################
+emulate -L zsh
+setopt local_options extended_glob
+
+local mode=screen term=""
+local -a filter_cats
+
+while (( $# )); do
+  case "$1" in
+    -h|--help)
+      fold -w "${COLUMNS:-$(tput cols)}" -s <<'EOF'
+Usage: cheat [TERM] [OPTIONS]
+Searchable reference for this shell's key bindings, aliases, and functions.
+
+Options:
+  --fzf         Open the interactive picker (bound to CTRL-G ?)
+  --keys        Show key bindings only
+  --list        Emit the raw TSV dataset, for scripting
+  --audit       Report drift between the shell config and omz/README.md
+  -h, --help    Show this help
+
+Arguments:
+  TERM          A category name, or any text to match against names and
+                summaries. Categories: keys, fzf-git, picker, git, k8s,
+                podman, files, crypto, ai, install, date, general, zsh,
+                bat, misc
+
+Examples:
+  cheat                 # everything, grouped and paged
+  cheat git             # just the git category
+  cheat fixup           # anything mentioning "fixup"
+  cheat --keys          # the one-screen key binding overview
+  cheat --fzf           # interactive picker with a preview pane
+EOF
+      return 0
+      ;;
+    --fzf)   mode=fzf ;;
+    --keys)  filter_cats=(keys fzf-git picker tmux tmux-pane tmux-tools tmux-copy) ;;
+    --list)  mode=list ;;
+    --audit) mode=audit ;;
+    -*)
+      pprint "🔴 cheat: unknown option: $1" "$fgRed" >&2
+      cheat --help >&2
+      return 1
+      ;;
+    *) term="$1" ;;
+  esac
+  shift
+done
+
+# --audit works on repo files, not the live shell, so it lives in a standalone
+# script that pre-commit can also run. $ZSH_CUSTOM/aliases.zsh is a symlink
+# back into the working tree, which is how we find the repo.
+if [[ "$mode" == audit ]]; then
+  local zc="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+  local repo
+  repo="$(readlink -f -- "$zc/aliases.zsh" 2>/dev/null)"
+  repo="${repo%/omz/aliases.zsh}"
+  if [[ -z "$repo" || ! -x "$repo/bin/cheatsheet_audit" ]]; then
+    pprint "🔴 cheat: could not locate the dotfiles repo from $zc/aliases.zsh" "$fgRed" >&2
+    return 1
+  fi
+  "$repo/bin/cheatsheet_audit" "$repo"
+  return $?
+fi
+
+# Build the dataset once, then narrow it. The picker also carries the
+# oh-my-zsh plugin aliases; the static screen omits them to stay glanceable.
+local -a data data_args
+[[ "$mode" == fzf ]] && data_args=(--all)
+data=("${(@f)$(_cheat_data "${data_args[@]}")}")
+data=("${(@)data:#}")
+
+# --keys narrows to the binding categories. The joined alternation has to go
+# through ${~...}, or zsh treats the expanded "a|b|c" as literal text.
+if (( ${#filter_cats} )); then
+  local cat_pat="(${(j:|:)filter_cats})"$'\t'"*"
+  data=("${(@M)data:#${~cat_pat}}")
+fi
+
+# A bare TERM is an exact category first, then a case-insensitive substring
+# match across the whole row. The category match also accepts a family prefix,
+# so "tmux" pulls in tmux-pane, tmux-tools, and tmux-copy alongside tmux.
+if [[ -n "$term" ]]; then
+  local -a matched
+  matched=("${(@M)data:#(#i)${term}(|-*)$'\t'*}")
+  (( ${#matched} )) || matched=("${(@M)data:#(#i)*${term}*}")
+  data=("${matched[@]}")
+fi
+
+if (( ! ${#data} )); then
+  pprint "🔴 cheat: nothing matched \"${term}\"" "$fgRed" >&2
+  return 1
+fi
+
+case "$mode" in
+  list)
+    print -rl -- "${data[@]}"
+    ;;
+  fzf)
+    print -rl -- "${data[@]}" | _cheat_fzf
+    ;;
+  screen)
+    if [[ -t 1 ]] && command -v less >/dev/null 2>&1; then
+      print -rl -- "${data[@]}" | _cheat_render | less -iRFX
+    elif [[ -t 1 ]]; then
+      print -rl -- "${data[@]}" | _cheat_render
+    else
+      print -rl -- "${data[@]}" | _cheat_render --no-color
+    fi
+    ;;
+esac

--- a/omz/functions/countdown
+++ b/omz/functions/countdown
@@ -1,5 +1,5 @@
 #######################################
-# countdown
+# countdown - Countdown timer that prints the remaining seconds
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/decode_cert
+++ b/omz/functions/decode_cert
@@ -1,5 +1,5 @@
 #######################################
-# decode_cert
+# decode_cert - Decode certificates in various levels of detail and formats
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/decode_jwt
+++ b/omz/functions/decode_jwt
@@ -1,5 +1,5 @@
 #######################################
-# decode_jwt
+# decode_jwt - Decode a JWT and format EPOCH timestamps to ISO 8601
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/gaf
+++ b/omz/functions/gaf
@@ -1,0 +1,20 @@
+#######################################
+# gaf - Stage git files picked with fzf
+# Arguments:
+#   None
+# Outputs:
+#   Interactive fzf selection of changed files, then git add
+# Returns:
+#   0 on success, 1 if fzf-git is unavailable or no selection made
+#######################################
+if ! command -v _fzf_git_files >/dev/null 2>&1; then
+  pprint "🔴 fzf-git is required, but not loaded." "$fgRed" >&2
+  return 1
+fi
+
+local -a files
+files=("${(@f)$(_fzf_git_files)}") || return 1
+files=("${(@)files:#}")
+(( ${#files} )) || return 1
+
+git add -- "${files[@]}"

--- a/omz/functions/gciaf
+++ b/omz/functions/gciaf
@@ -1,5 +1,5 @@
 #######################################
-# git commit all fixup
+# gciaf - git commit all fixup
 # Arguments:
 #   Commit hash to fixup
 # Outputs:

--- a/omz/functions/gcif
+++ b/omz/functions/gcif
@@ -1,5 +1,5 @@
 #######################################
-# git commit fixup
+# gcif - git commit fixup
 # Arguments:
 #   Commit hash to fixup
 # Outputs:

--- a/omz/functions/gcof
+++ b/omz/functions/gcof
@@ -1,0 +1,19 @@
+#######################################
+# gcof - Check out a git ref picked with fzf
+# Arguments:
+#   None
+# Outputs:
+#   Interactive fzf selection of refs, then git checkout
+# Returns:
+#   0 on success, 1 if fzf-git is unavailable or no selection made
+#######################################
+if ! command -v _fzf_git_each_ref >/dev/null 2>&1; then
+  pprint "🔴 fzf-git is required, but not loaded." "$fgRed" >&2
+  return 1
+fi
+
+local ref
+ref=$(_fzf_git_each_ref --no-multi) || return 1
+[[ -n "$ref" ]] || return 1
+
+git checkout "$ref"

--- a/omz/functions/gdu
+++ b/omz/functions/gdu
@@ -1,5 +1,5 @@
 #######################################
-# git diff with 0 lines of context
+# gdu - git diff with 0 lines of context
 # Arguments:
 #   Files to diff (optional, defaults to all)
 # Outputs:

--- a/omz/functions/gdus
+++ b/omz/functions/gdus
@@ -1,5 +1,5 @@
 #######################################
-# git diff staged with 0 lines of context
+# gdus - git diff staged with 0 lines of context
 # Arguments:
 #   Files to diff (optional, defaults to all)
 # Outputs:

--- a/omz/functions/get_k8s_images
+++ b/omz/functions/get_k8s_images
@@ -1,5 +1,5 @@
 #######################################
-# get_k8s_images
+# get_k8s_images - Get container images used by pods in a Kubernetes cluster
 #######################################
 if [[ $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/git_delete_head_semver_tags
+++ b/omz/functions/git_delete_head_semver_tags
@@ -1,5 +1,5 @@
 #######################################
-# git_delete_head_semver_tags
+# git_delete_head_semver_tags - Delete local semver tags that point at HEAD
 #######################################
 if [[ $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/git_pr_check
+++ b/omz/functions/git_pr_check
@@ -1,5 +1,5 @@
 #######################################
-# git_pr_check
+# git_pr_check - Check sub-directories for pull requests
 #######################################
 if [[ $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/git_tag_semver
+++ b/omz/functions/git_tag_semver
@@ -1,5 +1,5 @@
 #######################################
-# git_tag_semver
+# git_tag_semver - Semantically tag a git repository
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/grias
+++ b/omz/functions/grias
@@ -1,5 +1,5 @@
 #######################################
-# git rebase interactive autosquash
+# grias - git rebase interactive autosquash
 # Arguments:
 #   Commit ref to rebase from (optional, defaults to branch base)
 # Outputs:

--- a/omz/functions/gswt
+++ b/omz/functions/gswt
@@ -1,0 +1,19 @@
+#######################################
+# gswt - Switch to a git worktree picked with fzf
+# Arguments:
+#   None
+# Outputs:
+#   Interactive fzf selection of worktrees, then cd into it
+# Returns:
+#   0 on success, 1 if fzf-git is unavailable or no selection made
+#######################################
+if ! command -v _fzf_git_worktrees >/dev/null 2>&1; then
+  pprint "🔴 fzf-git is required, but not loaded." "$fgRed" >&2
+  return 1
+fi
+
+local worktree
+worktree=$(_fzf_git_worktrees --no-multi) || return 1
+[[ -n "$worktree" ]] || return 1
+
+cd "$worktree"

--- a/omz/functions/install_it
+++ b/omz/functions/install_it
@@ -1,5 +1,5 @@
 #######################################
-# install_it
+# install_it - Install an executable from ~/install to /usr/local/bin
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/install_kubectl
+++ b/omz/functions/install_kubectl
@@ -1,5 +1,5 @@
 #######################################
-# install_kubectl
+# install_kubectl - Install the specified version of kubectl, or the latest
 #######################################
 if [[ $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/joincsv
+++ b/omz/functions/joincsv
@@ -1,5 +1,5 @@
 #######################################
-# joincsv
+# joincsv - Add data from the second csv as a new column in the first csv
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/log_cmd
+++ b/omz/functions/log_cmd
@@ -1,5 +1,5 @@
 #######################################
-# log_cmd
+# log_cmd - Log a shell command, its stdout, and stderr to a file
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/log_cmd_d
+++ b/omz/functions/log_cmd_d
@@ -1,5 +1,5 @@
 #######################################
-# log_cmd_d
+# log_cmd_d - Log a shell command, its stdout, and stderr to a timestamped file
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/pprint
+++ b/omz/functions/pprint
@@ -1,5 +1,5 @@
 #######################################
-# pprint
+# pprint - Pretty print a string with color or text decorations
 #######################################
 if [[ $# -eq 0 || $1 == "--help" || $1 == "-h" ]]; then
   fold -w "$(tput cols)" -s <<'EOF'

--- a/omz/functions/update_git_mirrors_in_subdirs
+++ b/omz/functions/update_git_mirrors_in_subdirs
@@ -1,5 +1,5 @@
 #######################################
-# update all git mirrors in subdirectories of the current directory
+# update_git_mirrors_in_subdirs - ⚠ Update all git mirrors in subdirectories of the current directory
 # Arguments:
 #   None
 # Outputs:

--- a/omz/zshrc
+++ b/omz/zshrc
@@ -159,5 +159,22 @@ for file in "$ZSH_CUSTOM"/functions/*(.N); do
   autoload -Uz "${file:t}"
 done
 
+# CTRL-G ? opens the cheatsheet picker. This deliberately replaces the binding
+# fzf-git installs, which listed only the CTRL-G chords through `zle -M`; the
+# cheatsheet is a superset and is searchable. Must come after oh-my-zsh sources
+# $ZSH_CUSTOM/fzf.zsh, which is what runs __fzf_git_init.
+cheat-widget() {
+  local selected
+  selected="$(cheat --fzf)"
+  zle reset-prompt
+  [[ -n "$selected" ]] && LBUFFER+="$selected"
+}
+zle -N cheat-widget
+for keymap in emacs viins vicmd; do
+  bindkey -M "$keymap" '^g?' cheat-widget
+  bindkey -M "$keymap" '^g^?' cheat-widget
+done
+unset keymap
+
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [ ! -f ~/.p10k.zsh ] || source ~/.p10k.zsh

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -27,9 +27,9 @@ bind -n M-Down select-pane -D
 bind -n S-Left  previous-window
 bind -n S-Right next-window
 unbind '"'
-bind + split-window -h
+bind + split-window -h -c "#{pane_current_path}"
 unbind %
-bind - split-window -v
+bind - split-window -v -c "#{pane_current_path}"
 bind-key X set-window-option synchronize-panes\; display-message "synchronize-panes is now #{?pane_synchronized,on,off}"
 # END BINDINGS
 


### PR DESCRIPTION
Adds a searchable shell cheatsheet for shortcuts, aliases, functions, and tmux bindings, with both a static screen and an fzf picker bound to CTRL-G ?. It also adds drift checks so the cheatsheet stays aligned with the shell config and README.

# Changes

## Feature
- add cheat, a searchable shell cheatsheet with static and fzf views for key bindings, aliases, functions, and tmux bindings, plus an audit mode that catches config and docs drift

## Fix
- move gcof, gaf, and gswt into autoloaded functions so they are documented, completed, and covered by the cheatsheet; gaf now selects changed files correctly again
- refresh fzf-git bindings and preview layout, including the CTRL-/ preview toggle
- preserve the current working directory when tmux panes split
- add missing completions for helper functions and use a shared no-args completion for zero-argument commands

## Refactor
- standardize function docstring headers and add comments for every alias so cheatsheet parsing stays reliable

## CI
- add a pre-commit drift check so cheatsheet data and docs cannot diverge silently

## Docs
- refresh the cheatsheet README to explain the picker, categories, and data sources

## Build
- update VS Code peacock color customizations
